### PR TITLE
[ORION] feat(watchdog): ground-truth gate + proven/attest deny bar + sd_notify (Component 2)

### DIFF
--- a/infra/systemd/agents/elliot-context-watchdog.service
+++ b/infra/systemd/agents/elliot-context-watchdog.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Elliot context-cycling watchdog — wedge detect, restart, wake/resume + loud-death (HEAD-OF-OPS DIRECTIVE 2026-06-03)
+Documentation=scripts/orchestrator/context_watchdog.py
+After=network-online.target
+
+[Service]
+# Type=notify so systemd-notify WATCHDOG=1 from the script is honoured + a
+# missing heartbeat triggers restart. Was Type=oneshot — converting to notify
+# enables the loud-death guarantee in the dispatch directive.
+Type=notify
+NotifyAccess=all
+WatchdogSec=120s
+EnvironmentFile=-/home/elliotbot/.config/agency-os/.env
+WorkingDirectory=/home/elliotbot/clawd/Agency_OS-orion
+ExecStart=/home/elliotbot/clawd/Agency_OS/.venv/bin/python3 /home/elliotbot/clawd/Agency_OS-orion/scripts/orchestrator/context_watchdog.py
+Restart=on-failure
+RestartSec=10
+# Loud death: any non-zero exit OR missed WATCHDOG heartbeat → ops alert
+# fires via the existing keiracom-ops-failure-alert@.service template (drops
+# a #ceo line via slack_relay.py).
+OnFailure=keiracom-ops-failure-alert@%n.service
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -15,6 +15,7 @@ Full sequence per Dave directive 2026-05-31:
 
 Hard rule: NEVER auto-authorise paid chain runs.
 """
+
 from __future__ import annotations
 
 import hashlib
@@ -36,7 +37,7 @@ VENV_PYTHON = str(REPO / ".venv" / "bin" / "python3")
 
 ELLIOT_PANE = "elliottbot:0.0"
 WAKE_TIMEOUT_SEC = 1200  # 20 min — two timer cycles before escalating (was 600 = single-shot)
-IDLE_TIMEOUT_MIN = 40    # min idle (no pane change) before wake without restart
+IDLE_TIMEOUT_MIN = 40  # min idle (no pane change) before wake without restart
 
 AGENTS = {
     "atlas": "atlas:0.0",
@@ -49,10 +50,10 @@ AGENTS = {
 
 sys.path.insert(0, str(REPO))
 from dotenv import load_dotenv
+
 load_dotenv("/home/elliotbot/.config/agency-os/.env")
 
 from scripts.utils.tmux_send import (  # noqa: E402
-    pane_content as _pane_content_util,
     safe_send,
     wait_for_prompt,
 )
@@ -60,8 +61,9 @@ from scripts.utils.tmux_send import (  # noqa: E402
 
 def pane_capture(target: str) -> str:
     try:
-        r = subprocess.run(["tmux", "capture-pane", "-p", "-t", target],
-                           capture_output=True, text=True, timeout=5)
+        r = subprocess.run(
+            ["tmux", "capture-pane", "-p", "-t", target], capture_output=True, text=True, timeout=5
+        )
         return r.stdout if r.returncode == 0 else ""
     except Exception:
         return ""
@@ -86,7 +88,11 @@ def is_context_full(pane: str) -> bool:
 
 PERMISSION_PROMPT_TOKENS = ("⏵⏵", "bypass permiss")
 GENUINE_STALL_INDICATORS = (
-    "Error:", "APIError:", "ConnectionError", "TimeoutError", "Traceback",
+    "Error:",
+    "APIError:",
+    "ConnectionError",
+    "TimeoutError",
+    "Traceback",
 )
 # All tool-call prefix patterns that appear in Claude Code permission prompts.
 # MCP tools appear as "● mcp__<server>__<tool>(" in the pane.
@@ -97,36 +103,102 @@ AUTO_APPROVE_PATTERNS = [
     # which covers `git checkout -- .` (destructive working-tree reset) and
     # `git checkout main` (silent branch switch). Max HOLD blocker #1 on
     # PR #1385 (binding_dissent wire, Dave directive 2026-06-02).
-    "git log", "git status", "git diff", "git branch", "git show", "git grep",
-    "git add", "git commit", "git fetch", "git pull", "git stash", "git push",
-    "git checkout -b", "git rev-parse",
+    "git log",
+    "git status",
+    "git diff",
+    "git branch",
+    "git show",
+    "git grep",
+    "git add",
+    "git commit",
+    "git fetch",
+    "git pull",
+    "git stash",
+    "git push",
+    "git checkout -b",
+    "git rev-parse",
     # GitHub CLI — read. `gh api ` substring REMOVED — it cannot distinguish
     # read endpoints from write endpoints (`gh api … -X PUT/POST/DELETE` and
     # endpoints like `/pulls/N/merge` are writes wearing a read prefix). Max
     # HOLD blocker #2 on PR #1385.
-    "gh pr view", "gh pr list", "gh pr checks", "gh pr diff",
-    "gh issue view", "gh issue list",
-    "gh run view", "gh run list",
+    "gh pr view",
+    "gh pr list",
+    "gh pr checks",
+    "gh pr diff",
+    "gh issue view",
+    "gh issue list",
+    "gh run view",
+    "gh run list",
     # GitHub CLI — routine write ops. `gh pr merge` substring REMOVED —
     # merges land code in main and MUST gate on verified dual-concur, not on
     # an unconditional auto-approve. The verified path lives in
     # is_merge_with_dual_concur (PR comments must contain ≥2 REVIEW:approve
     # before send_tab fires). Max HOLD blocker #3 + binding_dissent
     # nucleus on PR #1385 (Dave directive 2026-06-02).
-    "gh pr comment", "gh pr create",
+    "gh pr comment",
+    "gh pr create",
     # tmux read ops
-    "tmux capture-pane", "tmux list-sessions", "tmux list-panes", "tmux list-windows",
+    "tmux capture-pane",
+    "tmux list-sessions",
+    "tmux list-panes",
+    "tmux list-windows",
     # Local scripts — diagnostic, test, lint (no external API spend)
-    "python3 scripts/", "python3 -m pytest", "python3 -B -m", "python3 -c ",
-    "python3 <<", "pytest", "ruff ", "mypy ",
+    "python3 scripts/",
+    "python3 -m pytest",
+    "python3 -B -m",
+    "python3 -c ",
+    "python3 <<",
+    "pytest",
+    "ruff ",
+    "mypy ",
     # Beads / bd task ops
-    "bd ready", "bd show", "bd close", "bd claim", "bd update", "bd create",
+    "bd ready",
+    "bd show",
+    "bd close",
+    "bd claim",
+    "bd update",
+    "bd create",
     # File + environment ops
-    "cat ", "ls ", "find ", "grep ", "head ", "tail ", "wc ", "echo ",
-    "source ", "env ", "which ", "type ",
+    "cat ",
+    "ls ",
+    "find ",
+    "grep ",
+    "head ",
+    "tail ",
+    "wc ",
+    "echo ",
+    "source ",
+    "env ",
+    "which ",
+    "type ",
 ]
 ESCALATION_COOLDOWN_SEC = 300  # 5 min — anti-spam window for unknown-tool escalations
 PR_NUMBER_RE = re.compile(r"·\s*PR\s*#(\d+)\s*·")
+
+# Structural proven/attest DENY bar (HEAD-OF-OPS DIRECTIVE 2026-06-03).
+# Any tool_str containing one of these patterns is HARD-DENIED by the watchdog —
+# no Tab is sent, the prompt stays pending for human decision, and the DENY is
+# logged to state[f"{name}_deny_log"] for audit. Supersedes both
+# AUTO_APPROVE_PATTERNS and is_merge_with_dual_concur.
+#
+# Rationale: status changes on gate_roadmap.* to 'proven' AND gh pr merge land
+# code/state that affects ratified-decisions surface. Those must go through a
+# human, not the watchdog's pattern matcher.
+STRUCTURAL_DENY_SUBSTRINGS = (
+    "status=proven",
+    "gate_proof_runs",
+    "gh pr merge",
+)
+STRUCTURAL_DENY_REGEXES = (re.compile(r"INSERT.*proven", re.IGNORECASE),)
+
+# Ground-truth progress sources (HEAD-OF-OPS DIRECTIVE 2026-06-03).
+# If ANY of these shows activity within IDLE_TIMEOUT_MIN, the fleet is NOT
+# stalled — the watchdog should skip revive even if a pane looks idle.
+WORKER_LOG_PATHS = (
+    Path("/home/elliotbot/clawd/logs/keiracom-temporal-worker.log"),
+    Path("/home/elliotbot/clawd/logs/dispatcher.log"),
+    Path("/home/elliotbot/clawd/logs/fleet-supervisor.log"),
+)
 
 
 def is_permission_prompt(pane: str) -> bool:
@@ -140,7 +212,7 @@ def is_permission_prompt(pane: str) -> bool:
     if not any(tok in pane for tok in PERMISSION_PROMPT_TOKENS):
         return False
     has_tool_call = any(prefix in pane for prefix in TOOL_CALL_PREFIXES)
-    has_allow_deny = ("Allow" in pane and ("Deny" in pane or "Tab to" in pane))
+    has_allow_deny = "Allow" in pane and ("Deny" in pane or "Tab to" in pane)
     return has_tool_call or has_allow_deny
 
 
@@ -190,6 +262,106 @@ def is_auto_approvable(tool_str: str) -> bool:
     return any(pat in tool_str for pat in AUTO_APPROVE_PATTERNS)
 
 
+def is_structurally_denied(tool_str: str) -> bool:
+    """True iff `tool_str` matches any STRUCTURAL_DENY pattern (HARD DENY).
+
+    Overrides every auto-approve path. The watchdog must NOT advance the
+    permission prompt; the human reviews + decides.
+    """
+    if not tool_str:
+        return False
+    if any(sub in tool_str for sub in STRUCTURAL_DENY_SUBSTRINGS):
+        return True
+    return any(rx.search(tool_str) for rx in STRUCTURAL_DENY_REGEXES)
+
+
+def _git_recent_commit(since_seconds: int) -> bool:
+    try:
+        r = subprocess.run(
+            ["git", "log", f"--since={since_seconds} seconds ago", "--oneline", "-1"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            cwd=str(REPO),
+            check=False,
+        )
+        return r.returncode == 0 and bool(r.stdout.strip())
+    except Exception:
+        return False
+
+
+def _gate_roadmap_recent_change(since_seconds: int) -> bool:
+    """Postgres lookup — any gate_roadmap_history row in the last `since_seconds`."""
+    try:
+        import psycopg  # noqa: PLC0415
+    except ImportError:
+        return False
+    dsn = os.environ.get("DATABASE_URL_MIGRATIONS") or os.environ.get("DATABASE_URL", "")
+    dsn = dsn.replace("postgresql+asyncpg://", "postgresql://", 1)
+    if not dsn:
+        return False
+    try:
+        with (
+            psycopg.connect(dsn, prepare_threshold=None, connect_timeout=5) as conn,
+            conn.cursor() as cur,
+        ):
+            cur.execute(
+                "SELECT 1 FROM public.gate_roadmap_history "
+                "WHERE changed_at > NOW() - make_interval(secs => %s) LIMIT 1",
+                (since_seconds,),
+            )
+            return cur.fetchone() is not None
+    except Exception:
+        return False
+
+
+def _worker_log_recent_mtime(since_seconds: int) -> bool:
+    cutoff = time.time() - since_seconds
+    for p in WORKER_LOG_PATHS:
+        try:
+            if p.exists() and p.stat().st_mtime > cutoff:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def check_ground_truth_progress(since_seconds: int) -> bool:
+    """True iff ANY ground-truth source shows progress in the last `since_seconds`.
+
+    Sources:
+      1. public.gate_roadmap_history (status changes).
+      2. Worker log mtime (Temporal worker / dispatcher / fleet-supervisor).
+      3. Recent git commits in the repo.
+
+    Used before declaring an agent 'stalled' — if the fleet is shipping work,
+    individual pane idleness is not stall.
+    """
+    if since_seconds <= 0:
+        return False
+    return (
+        _gate_roadmap_recent_change(since_seconds)
+        or _worker_log_recent_mtime(since_seconds)
+        or _git_recent_commit(since_seconds)
+    )
+
+
+def sd_notify_watchdog() -> None:
+    """Send WATCHDOG=1 heartbeat to systemd if NOTIFY_SOCKET is wired.
+
+    Harmless on Type=oneshot units (NotifyAccess defaults make this a no-op);
+    enables the systemd watchdog timer when the unit is converted to
+    Type=notify + WatchdogSec=N (see infra/systemd/agents/elliot-context-
+    watchdog.service for the converted unit + companion ops alert).
+    """
+    if not os.environ.get("NOTIFY_SOCKET"):
+        return
+    try:
+        subprocess.run(["systemd-notify", "WATCHDOG=1"], timeout=2, check=False)
+    except Exception:
+        pass
+
+
 def is_merge_with_dual_concur(tool_str: str, pr_number: int | None) -> bool:
     """True iff the pending tool is `gh pr merge` AND the PR shows 2+ REVIEW:approve.
 
@@ -200,9 +372,11 @@ def is_merge_with_dual_concur(tool_str: str, pr_number: int | None) -> bool:
         return False
     try:
         r = subprocess.run(
-            ["gh", "pr", "view", str(pr_number), "--json", "comments", "-q",
-             ".comments[].body"],
-            capture_output=True, text=True, timeout=15, check=False,
+            ["gh", "pr", "view", str(pr_number), "--json", "comments", "-q", ".comments[].body"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
         )
         if r.returncode != 0:
             return False
@@ -215,8 +389,7 @@ def is_merge_with_dual_concur(tool_str: str, pr_number: int | None) -> bool:
 def send_tab(target: str) -> None:
     """Send a single Tab keystroke to a tmux pane (advances past a Claude prompt)."""
     try:
-        subprocess.run(["tmux", "send-keys", "-t", target, "Tab"],
-                       timeout=5, check=False)
+        subprocess.run(["tmux", "send-keys", "-t", target, "Tab"], timeout=5, check=False)
     except Exception:
         pass
 
@@ -235,6 +408,30 @@ def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> 
     now = time.time()
     tool_str = extract_pending_tool(pane)
     pr_number = extract_pr_number(pane)
+
+    # Structural proven/attest bar fires FIRST — overrides every auto-approve
+    # path. Tab is NOT sent; prompt stays pending. DENY logged to state file.
+    if tool_str is not None and is_structurally_denied(tool_str):
+        deny_log = state.setdefault(f"{name}_deny_log", [])
+        deny_log.append(
+            {
+                "ts": now,
+                "tool": tool_str[:200],
+                "reason": "structural_deny_proven_or_merge",
+            }
+        )
+        # Cap to last 50 entries to keep state file bounded.
+        state[f"{name}_deny_log"] = deny_log[-50:]
+        last_escalated = state.get(f"{name}_escalated_at", 0)
+        if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
+            slack_ceo(
+                f"[ELLIOT] Watchdog DENIED {name}: structural bar (proven/merge). "
+                f"Tool: {tool_str[:120]}. Prompt left pending — needs human."
+            )
+            state[f"{name}_escalated_at"] = now
+        print(f"[watchdog] DENY {name}: {tool_str[:80]}")
+        return state
+
     if tool_str is None:
         # Tool not visible above ⏵⏵ — report once per cooldown, then send Tab.
         last_escalated = state.get(f"{name}_escalated_at", 0)
@@ -310,15 +507,19 @@ def record_agent_task(name: str, task_summary: str) -> None:
 
 def slack_ceo(msg: str) -> None:
     try:
-        subprocess.run([VENV_PYTHON, SLACK_RELAY, "--channel", "ceo", "--text", msg],
-                       env={**os.environ, "CALLSIGN": "elliot"},
-                       timeout=15, check=False)
+        subprocess.run(
+            [VENV_PYTHON, SLACK_RELAY, "--channel", "ceo", "--text", msg],
+            env={**os.environ, "CALLSIGN": "elliot"},
+            timeout=15,
+            check=False,
+        )
     except Exception:
         pass
 
 
 # send_pane and wait_for_prompt are now imported from scripts.utils.tmux_send.
 # Thin wrappers kept for callers that pass delay= kwargs.
+
 
 def send_pane(target: str, text: str, delay: float = 0) -> bool:
     """Verified pane injection via scripts.utils.tmux_send.safe_send.
@@ -333,9 +534,9 @@ def send_pane(target: str, text: str, delay: float = 0) -> bool:
 def ensure_compact_state() -> str:
     """Refresh compact state file. Returns content."""
     try:
-        subprocess.run([VENV_PYTHON, WRITE_COMPACT], timeout=30,
-                       cwd=str(REPO), check=False,
-                       env={**os.environ})
+        subprocess.run(
+            [VENV_PYTHON, WRITE_COMPACT], timeout=30, cwd=str(REPO), check=False, env={**os.environ}
+        )
     except Exception:
         pass
     if STATE_FILE.exists():
@@ -489,16 +690,24 @@ def check_other_agents(state: dict) -> dict:
             continue
 
         last_task = state.get(f"{name}_last_task", "")
+        # Context-full is a structural pane signal — revive regardless of
+        # ground-truth (the agent itself cannot continue without a /clear).
         if is_context_full(pane):
             revive_agent(name, target, "context-full", last_task=last_task)
             state[key_revive] = now
         elif is_genuinely_stuck(pane):
+            # Ground-truth gate: if the fleet is shipping work in the recent
+            # window, individual pane idleness is not a stall — skip revive.
+            if check_ground_truth_progress(IDLE_TIMEOUT_MIN * 60):
+                print(f"[watchdog] {name} pane idle but ground-truth shows progress — skip revive")
+                continue
             revive_agent(name, target, "error-detected", last_task=last_task)
             state[key_revive] = now
     return state
 
 
 def main() -> None:
+    sd_notify_watchdog()
     now = time.time()
     state = load_state()
 
@@ -529,14 +738,20 @@ def main() -> None:
         if elliot_hash == state.get("elliot_last_hash", ""):
             slack_ceo(
                 "[ELLIOT] Watchdog: auto-resume FAILED — Elliot pane unchanged "
-                f"{WAKE_TIMEOUT_SEC//60}min after restart. Needs manual intervention."
+                f"{WAKE_TIMEOUT_SEC // 60}min after restart. Needs manual intervention."
             )
             state["elliot_wake_sent"] = 0  # reset to avoid spam loop
     elif not wake_sent:
         # No active wake; check for idle-too-long (Problem B standalone)
         idle_secs = now - state.get("elliot_last_hash_ts", now)
         if idle_secs > IDLE_TIMEOUT_MIN * 60:
-            state = wake_idle_elliot(state, now)
+            # Ground-truth gate: fleet shipping work means Elliot isn't the
+            # blocker — skip the wake. Prevents nuisance pings during deep
+            # multi-agent work where Elliot's pane is correctly quiet.
+            if check_ground_truth_progress(IDLE_TIMEOUT_MIN * 60):
+                print("[watchdog] elliot idle but ground-truth shows progress — skip wake")
+            else:
+                state = wake_idle_elliot(state, now)
 
     # ── Other agents ─────────────────────────────────────────────────────
     state = check_other_agents(state)

--- a/tests/orchestrator/test_context_watchdog.py
+++ b/tests/orchestrator/test_context_watchdog.py
@@ -141,11 +141,17 @@ def test_revive_agent_falls_back_to_bd_ready_when_last_task_blank(cw, monkeypatc
 
 
 def _stub_one_agent(cw, monkeypatch, *, pane_text: str):
-    """Reduce AGENTS to a single test agent + stub pane_capture to return pane_text."""
+    """Reduce AGENTS to a single test agent + stub pane_capture to return pane_text.
+
+    Also forces check_ground_truth_progress() to False so the legacy
+    revive-on-genuinely-stuck assertion holds. The ground-truth gate
+    (HEAD-OF-OPS 2026-06-03) is exercised in its own tests below.
+    """
     monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
     monkeypatch.setattr(cw, "pane_capture", lambda _target: pane_text)
     monkeypatch.setattr(cw, "send_pane", lambda *a, **kw: None)
     monkeypatch.setattr(cw, "slack_ceo", lambda _msg: None)
+    monkeypatch.setattr(cw, "check_ground_truth_progress", lambda _secs: False)
 
 
 def test_check_other_agents_sets_revive_sent_after_reviving(cw, monkeypatch):
@@ -254,6 +260,7 @@ def test_check_other_agents_passes_last_task_to_revive(cw, monkeypatch):
     monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
     monkeypatch.setattr(cw, "pane_capture", lambda _t: "Traceback (most recent call):\n...")
     monkeypatch.setattr(cw, "revive_agent", fake_revive)
+    monkeypatch.setattr(cw, "check_ground_truth_progress", lambda _secs: False)
 
     cw.check_other_agents({"aiden_last_task": "KEI-42: wire foo"})
     assert received == {
@@ -335,6 +342,7 @@ def test_record_then_revive_uses_persisted_last_task(cw, tmp_path, monkeypatch):
     monkeypatch.setattr(cw, "AGENTS", {"aiden": "aiden:0.0"})
     monkeypatch.setattr(cw, "pane_capture", lambda _t: "...\nError: oh no")
     monkeypatch.setattr(cw, "revive_agent", fake_revive)
+    monkeypatch.setattr(cw, "check_ground_truth_progress", lambda _secs: False)
 
     cw.check_other_agents(cw.load_state())
     assert received["last_task"] == "KEI-77: rebase PR after #1371"
@@ -410,9 +418,9 @@ def test_unknown_tool_escalates_and_sends_tab(cw, monkeypatch):
     pane = _perm_pane("Bash(rm -rf /tmp/foo)")
     state = cw.handle_permission_prompt("aiden", "aiden:0.0", pane, {})
 
-    assert tabs == ["aiden:0.0"]          # Tab sent — agent unblocked
+    assert tabs == ["aiden:0.0"]  # Tab sent — agent unblocked
     assert len(slack) == 1
-    assert "auto-approved" in slack[0]    # reported as auto-approved, not just escalated
+    assert "auto-approved" in slack[0]  # reported as auto-approved, not just escalated
     assert "rm -rf /tmp/foo" in slack[0]
     assert state["aiden_escalated_at"] > 0
 
@@ -432,8 +440,12 @@ def test_escalation_anti_spam(cw, monkeypatch):
     assert len(slack) == 1, "anti-spam cooldown should suppress the second escalation"
 
 
-def test_merge_with_dual_concur_auto_approves(cw, monkeypatch):
-    """gh pr merge + 2+ REVIEW:approve in PR comments → Tab keystroke."""
+def test_merge_with_dual_concur_is_structurally_denied(cw, monkeypatch):
+    """gh pr merge is now HARD-DENIED by structural bar (HEAD-OF-OPS 2026-06-03).
+
+    Even with 2+ REVIEW:approve in comments, the watchdog refuses to send Tab —
+    merges to main require human action, not pattern-match auto-approval.
+    """
     tabs: list[str] = []
     slack: list[str] = []
     monkeypatch.setattr(cw, "send_tab", lambda t: tabs.append(t))
@@ -446,10 +458,13 @@ def test_merge_with_dual_concur_auto_approves(cw, monkeypatch):
     monkeypatch.setattr(cw.subprocess, "run", lambda *a, **kw: _R())
 
     pane = _perm_pane("Bash(gh pr merge 1375 --squash --admin)", pr=1375)
-    cw.handle_permission_prompt("elliot", "elliottbot:0.0", pane, {})
+    state = cw.handle_permission_prompt("elliot", "elliottbot:0.0", pane, {})
 
-    assert tabs == ["elliottbot:0.0"]
-    assert slack == []
+    assert tabs == [], "structural deny must NOT send Tab on gh pr merge"
+    assert len(slack) == 1, "first DENY escalates to #ceo"
+    assert "DENIED elliot" in slack[0]
+    assert "elliot_deny_log" in state and state["elliot_deny_log"]
+    assert state["elliot_deny_log"][-1]["reason"] == "structural_deny_proven_or_merge"
 
 
 # ─── AUTO_APPROVE_PATTERNS expansion (2026-06-01) ──────────────────────────────
@@ -601,7 +616,7 @@ def test_unidentified_tool_escalation_includes_pane_tail(cw, monkeypatch):
 
     assert len(slack) == 1, "exactly one escalation must fire"
     msg = slack[0]
-    assert "unidentified" in msg         # "unidentified prompt, Tab auto-sent"
+    assert "unidentified" in msg  # "unidentified prompt, Tab auto-sent"
     # Pane-tail contract: last 3 non-empty lines, joined with " | "
     assert "Waiting for service registry registration" in msg
     assert "Approve y/N" in msg

--- a/tests/orchestrator/test_watchdog_context_cycle.py
+++ b/tests/orchestrator/test_watchdog_context_cycle.py
@@ -1,0 +1,73 @@
+"""Negative test A — context-cycle revive path for non-Elliot agents.
+
+Per HEAD-OF-OPS DIRECTIVE 2026-06-03 (Component 2 of 2), exercise the
+context-full revive path in scripts.orchestrator.context_watchdog:
+
+  (a) mocks a pane with '100% context used'
+  (b) confirms is_context_full() returns True
+  (c) mocks /clear + wake-prompt injection
+  (d) confirms the agent gets re-briefed
+
+Pattern matches the existing tests/orchestrator/test_context_watchdog.py:
+monkeypatch the side-effecting seams (pane_capture, safe_send, slack_ceo,
+wait_for_prompt) so no real tmux/Slack/DB is touched.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def cw():
+    """Fresh import of the watchdog module per test so monkeypatched
+    module-level attrs don't bleed between tests."""
+    mod = importlib.import_module("scripts.orchestrator.context_watchdog")
+    return importlib.reload(mod)
+
+
+def test_a_context_full_pane_triggers_revive(cw, monkeypatch):
+    """(a)+(b)+(c)+(d) negative test A — happy-path revive on context-full."""
+
+    # (a) Mock pane with '100% context used'.
+    fake_pane = "some scrollback content here\nmore scrollback\n100% context used\n❯ \n"
+
+    # Restrict to a single target agent so the loop runs deterministically.
+    monkeypatch.setattr(cw, "AGENTS", {"orion": "orion:0.0"})
+
+    # pane_capture: return fake_pane every call.
+    monkeypatch.setattr(cw, "pane_capture", lambda _target: fake_pane)
+
+    # (b) Sanity: is_context_full() returns True for this pane.
+    assert cw.is_context_full(fake_pane) is True
+
+    # (c) Mock /clear + wake-prompt injection: capture safe_send + slack_ceo.
+    sends: list[tuple[str, str]] = []
+
+    def fake_safe_send(target, text, **_kwargs):
+        sends.append((target, text))
+        return True
+
+    monkeypatch.setattr(cw, "safe_send", fake_safe_send)
+    monkeypatch.setattr(cw, "wait_for_prompt", lambda _t, timeout=0: True)
+
+    slack_msgs: list[str] = []
+    monkeypatch.setattr(cw, "slack_ceo", lambda msg: slack_msgs.append(msg))
+
+    # Run the revive path under test.
+    cw.check_other_agents({})
+
+    # (d) Confirm the agent got re-briefed.
+    targets = [t for t, _ in sends]
+    texts = [text for _, text in sends]
+
+    assert "orion:0.0" in targets, f"expected /clear+revive sent to orion:0.0, got: {targets}"
+    assert any(s == "/clear" for s in texts), f"expected /clear keystroke; sends={texts}"
+    assert any("REVIVED by watchdog" in s and "context-full" in s for s in texts), (
+        f"expected REVIVED context-full message; sends={texts}"
+    )
+    assert any("revived orion" in m.lower() and "context-full" in m for m in slack_msgs), (
+        f"expected #ceo announcement of revive; got: {slack_msgs}"
+    )


### PR DESCRIPTION
## Summary

Per HEAD-OF-OPS DIRECTIVE 2026-06-03 (Component 2 of 2). References
`gate_roadmap_id = cd5de3a1-4944-4e14-93bf-dfbbb8f44598` (`continuous_operation_hooks`, `0_foundation`, `not_started`, `binding_reviewer`).

Three watchdog enhancements + Negative Test A + systemd-unit refresh.

## Enhancements

### 1. Ground-truth check — `check_ground_truth_progress(since_seconds) -> bool`

Three sources, ANY positive → True:
- `public.gate_roadmap_history` rows changed in window (psycopg, fail-open)
- Worker log mtime (Temporal worker / dispatcher / fleet-supervisor)
- Recent git commits (`git log --since="<n> seconds ago"`)

Hooked into:
- `check_other_agents()` — genuinely-stuck pane skips revive if fleet shipping
- `main()` — Elliot idle-wake skipped if fleet shipping

Context-full panes **still revive** (structural — agent cannot self-recover regardless of fleet state).

### 2. Structural proven/attest DENY bar — `is_structurally_denied(tool_str)`

Patterns:
- `status=proven` (substring)
- `gate_proof_runs` (substring)
- `gh pr merge` (substring)
- `r'INSERT.*proven'` (regex, case-insensitive)

Fires FIRST in `handle_permission_prompt`, overriding `AUTO_APPROVE_PATTERNS` and `is_merge_with_dual_concur`. Behavior on match:
- NO Tab keystroke — prompt stays pending for human decision
- DENY logged to `state[f"{name}_deny_log"]` (last-50 cap, audit trail)
- First DENY per cooldown window escalates to #ceo

This is a strictly tighter policy than the prior dual-concur auto-merge path.

### 3. Loud-death `sd_notify_watchdog()` — top of `main()`

No-op on `Type=oneshot`. Honoured on `Type=notify` + `WatchdogSec=N` (the unit below). Missed heartbeat → systemd restart → `OnFailure=` posts to #ceo.

## Systemd unit update (NOTE FOR DEVOPS)

`infra/systemd/agents/elliot-context-watchdog.service`:
- `Type=notify` + `NotifyAccess=all` + `WatchdogSec=120s`
- `Restart=on-failure` + `RestartSec=10`
- `OnFailure=keiracom-ops-failure-alert@%n.service` (loud-death → #ceo)
- `WorkingDirectory=/home/elliotbot/clawd/Agency_OS-orion` (live worker pwd)

The live unit at `~/.config/systemd/user/elliot-context-watchdog.service` is currently `Type=oneshot`. To activate the loud-death + watchdog-timeout behaviour, devops must copy this repo file → `~/.config/systemd/user/` and `systemctl --user daemon-reload` + restart the unit. Until then, the `sd_notify` call is a no-op and the watchdog still runs as a oneshot.

## Negative Test A — verbatim output

```
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /home/elliotbot/clawd/Agency_OS/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/elliotbot/clawd/Agency_OS-orion
configfile: pytest.ini
plugins: logfire-4.22.0, timeout-2.4.0, asyncio-1.3.0, typeguard-4.5.1, anyio-4.12.1
timeout: 300.0s
timeout method: thread
timeout func_only: False
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... collected 1 item

tests/orchestrator/test_watchdog_context_cycle.py::test_a_context_full_pane_triggers_revive PASSED [100%]

============================== 1 passed in 0.12s ===============================
EXIT=0
```

Full regression: **87 passed in 7.51s**.

## Regression updates to existing tests

- `_stub_one_agent` helper now stubs `check_ground_truth_progress → False` so legacy revive-on-genuinely-stuck assertions hold. Two non-helper tests get the same stub added inline.
- `test_merge_with_dual_concur_auto_approves` renamed to `test_merge_with_dual_concur_is_structurally_denied` — asserts NEW behavior: gh pr merge is HARD-DENIED even with 2+ REVIEW:approve in PR comments. Per dispatch directive ("hard DENY for ... 'gh pr merge'").

## Attestation pathway

Hold per dispatch: **do NOT insert proof_run** until BOTH negative tests A AND B pass verbatim. This PR delivers Negative Test A. Test B is on the companion Atlas PR for `continuous_operation_hooks`. Aiden+Max attest binding_reviewer against `gate_roadmap_id = cd5de3a1-4944-4e14-93bf-dfbbb8f44598` after both PRs ship.

## What this PR is + isn't

- ✅ `scripts/orchestrator/context_watchdog.py` enhanced — 3 directive items
- ✅ `tests/orchestrator/test_watchdog_context_cycle.py` — Negative Test A
- ✅ `infra/systemd/agents/elliot-context-watchdog.service` — converted unit
- ✅ `tests/orchestrator/test_context_watchdog.py` — regression updates
- ❌ Did NOT touch `gate_roadmap` or `gate_proof_runs` (per dispatch scope)
- ❌ Did NOT modify live `~/.config/systemd/user/` unit (devops action)

## Test plan

- [x] Negative Test A passes (verbatim above)
- [x] Full regression (`tests/orchestrator/`): 87 passed
- [x] `ruff check` + `ruff format --check` clean on `src/` (CI lint scope)
- [ ] DevOps copies new unit + reloads (separate operational step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)