### PR TITLE
[ORION] fix(watchdog): SECURITY P1 — redact DSN / PGPASSWORD / Bearer in Slack posts

### DIFF
--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -191,6 +191,27 @@ STRUCTURAL_DENY_SUBSTRINGS = (
 )
 STRUCTURAL_DENY_REGEXES = (re.compile(r"INSERT.*proven", re.IGNORECASE),)
 
+# Credential-redaction patterns (SECURITY P1, 2026-06-03). Any pane content
+# that flows into slack_ceo() must pass through _redact_secrets() first —
+# panes can carry psql DSNs, PGPASSWORD env lines, bearer tokens.
+_REDACT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"postgresql(\+\w+)?://[^@\s]+@"), r"postgresql\1://***@"),
+    (re.compile(r"(PGPASSWORD)=\S+"), r"\1=***"),
+    (re.compile(r"(DATABASE_URL)=\S+"), r"\1=***"),
+    (re.compile(r":[^:@/\s]{8,}@"), ":***@"),
+    (re.compile(r"Bearer [A-Za-z0-9_.\-]{20,}"), "Bearer ***"),
+)
+
+
+def _redact_secrets(text: str) -> str:
+    """Mask credential patterns before they hit Slack."""
+    if not text:
+        return text
+    for pat, repl in _REDACT_PATTERNS:
+        text = pat.sub(repl, text)
+    return text
+
+
 # Ground-truth progress sources (HEAD-OF-OPS DIRECTIVE 2026-06-03).
 # If ANY of these shows activity within IDLE_TIMEOUT_MIN, the fleet is NOT
 # stalled — the watchdog should skip revive even if a pane looks idle.
@@ -426,7 +447,7 @@ def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> 
         if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
             slack_ceo(
                 f"[ELLIOT] Watchdog DENIED {name}: structural bar (proven/merge). "
-                f"Tool: {tool_str[:120]}. Prompt left pending — needs human."
+                f"Tool: {_redact_secrets(tool_str[:120])}. Prompt left pending — needs human."
             )
             state[f"{name}_escalated_at"] = now
         print(f"[watchdog] DENY {name}: {tool_str[:80]}")
@@ -437,7 +458,7 @@ def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> 
         last_escalated = state.get(f"{name}_escalated_at", 0)
         if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
             tail_lines = [ln.strip() for ln in pane.splitlines() if ln.strip()][-3:]
-            pane_tail = " | ".join(tail_lines)
+            pane_tail = _redact_secrets(" | ".join(tail_lines))
             slack_ceo(
                 f"[ELLIOT] Watchdog: {name} — unidentified prompt, Tab auto-sent.\n"
                 f"Pane tail: {pane_tail[:200]}"
@@ -461,7 +482,7 @@ def handle_permission_prompt(name: str, target: str, pane: str, state: dict) -> 
     last_escalated = state.get(f"{name}_escalated_at", 0)
     if now - last_escalated >= ESCALATION_COOLDOWN_SEC:
         slack_ceo(
-            f"[ELLIOT] Watchdog: {name} — non-standard tool auto-approved: {tool_str[:120]}\n"
+            f"[ELLIOT] Watchdog: {name} — non-standard tool auto-approved: {_redact_secrets(tool_str[:120])}\n"
             "Tab sent — agent unblocked. Review if unexpected."
         )
         state[f"{name}_escalated_at"] = now

--- a/tests/orchestrator/test_watchdog_redact_secrets.py
+++ b/tests/orchestrator/test_watchdog_redact_secrets.py
@@ -1,0 +1,45 @@
+"""Tests for _redact_secrets (SECURITY P1, 2026-06-03).
+
+Confirm the watchdog masks credentials before any pane content reaches Slack:
+  - postgresql DSNs (with or without +driver suffix)
+  - PGPASSWORD / DATABASE_URL env-style lines
+  - generic ':long-secret@' DSN passwords
+  - Bearer tokens
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def cw():
+    mod = importlib.import_module("scripts.orchestrator.context_watchdog")
+    return importlib.reload(mod)
+
+
+@pytest.mark.parametrize(
+    ("raw", "must_be_absent"),
+    [
+        ("psql postgresql://user:s3cretpassword@db.host:5432/x", "s3cretpassword"),
+        ("DSN postgresql+asyncpg://u:hunter22extra@host/db", "hunter22extra"),
+        ("env PGPASSWORD=topsecretvalue123 set", "topsecretvalue123"),
+        ("DATABASE_URL=postgresql://u:p@h/d AS dsn", "DATABASE_URL=postgresql"),
+        ("redis://:longpasswordvalue@cache.host:6379/0", "longpasswordvalue"),
+        ("Authorization: Bearer abcdefghijklmnopqrstuvwxyz0123", "abcdefghijklmnopqrstuvwxyz0123"),
+    ],
+)
+def test_redact_secrets_masks_known_patterns(cw, raw, must_be_absent):
+    out = cw._redact_secrets(raw)
+    assert must_be_absent not in out, f"secret leaked: {out!r}"
+    assert "***" in out, f"expected mask marker; got {out!r}"
+
+
+def test_redact_secrets_passes_through_safe_text(cw):
+    assert cw._redact_secrets("just a normal log line") == "just a normal log line"
+
+
+def test_redact_secrets_handles_empty(cw):
+    assert cw._redact_secrets("") == ""


### PR DESCRIPTION
## Summary

**SECURITY P1.** The watchdog posted raw pane tail lines to #ceo. Any agent's pane that contained a psql DSN with plaintext password, a `PGPASSWORD=` env line, or a `Bearer …` token got leaked.

This PR adds `_redact_secrets(text)` and applies it to **all three Slack-leak sites** in `handle_permission_prompt`.

## What changed

### `scripts/orchestrator/context_watchdog.py`

- `_REDACT_PATTERNS` module-level tuple + `_redact_secrets(text)` helper. Patterns:
  - `postgresql(\+driver)?://USER:PASS@host` → `postgresql://***@`
  - `PGPASSWORD=…` → `PGPASSWORD=***`
  - `DATABASE_URL=…` → `DATABASE_URL=***`
  - Generic `:long-secret@` DSN passwords → `:***@`
  - `Bearer [A-Za-z0-9_.\-]{20,}` → `Bearer ***`
- Wired into the three Slack-leak sites in `handle_permission_prompt`:
  1. Structural-deny path — `Tool: {tool_str[:120]}` (added by PR #1415)
  2. Unidentified-prompt path — `Pane tail: {pane_tail[:200]}` (original dispatch site)
  3. Non-standard-tool path — `auto-approved: {tool_str[:120]}` (original dispatch site)

### `tests/orchestrator/test_watchdog_redact_secrets.py` (new)

8 tests:
- 6 parametrised cases — one per pattern; assert secret absent + `***` mask marker present.
- 1 pass-through case — no secrets in input, no edits.
- 1 empty-string case.

## Verification

```
pytest tests/orchestrator/test_watchdog_redact_secrets.py → 8 passed in 0.34s, EXIT=0
pytest tests/orchestrator/test_context_watchdog.py + resume + cycle → 87 passed
```

`ruff check` / `ruff format --check` clean on `src/` (CI lint scope). Pre-existing SIM105 in `scripts/` unchanged (matches surrounding code style).

## Scope notes

- `state[f"{name}_deny_log"]` is intentionally left unredacted — that's on-disk audit, not Slack. Dispatch scope: redaction before Slack only. If the directive expands to cover state files, easy follow-up.
- `print(...)` calls to stdout/journal also unredacted — same reasoning (not Slack).

## Test plan

- [x] 8 new redact tests pass
- [x] 87 pre-existing orchestrator tests pass (no regressions)
- [x] `ruff check src/` + `ruff format --check src/` clean
- [ ] After merge: live Negative Test A confirms watchdog still detects context-full (Task 2 of this dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)