### PR TITLE
[SCOUT] feat(chain): ReviewerAtom verdict schema + parse_reviewer_verdict (scout-reviewer-atom-schema-phase1)

### DIFF
--- a/src/keiracom_system/chain/reviewer_atom.py
+++ b/src/keiracom_system/chain/reviewer_atom.py
@@ -1,0 +1,186 @@
+"""ReviewerAtom — structured verdict schema for V1 chain reviewer output.
+
+Coordination point with Atlas's verdict_enforcement wiring in advance_step.
+Reviewers (orion, atlas) currently emit free-text atoms whose first line starts
+with one of REJECT / CONCUR / HOLD / APPROVE. advance_step needs a reliable
+way to extract that verdict from any reviewer atom by atom_id.
+
+This module provides:
+  - ReviewerAtom dataclass (frozen): verdict + rationale + atom_id (+ raw atom).
+  - Verdict literal: APPROVE | HOLD | REJECT (the three Atlas's enforcement
+    layer needs to discriminate on).
+  - parse_reviewer_verdict(atom_id, *, fetcher=None) -> ReviewerAtom.
+    Returns verdict='HOLD' (safe default) when the atom can't be fetched, the
+    atom is empty, or no recognisable verdict token is found in its content.
+
+Vocabulary alignment with personas (personas/v1_chain/{orion,atlas}.md):
+  - Personas today emit REJECT and CONCUR.
+  - This schema normalises CONCUR -> APPROVE so advance_step has a single
+    enum to switch on. HOLD is added per dispatch (covers the unknown /
+    fetch-failure / safe-default case).
+
+Safe-default principle: a missing or malformed verdict NEVER advances the
+chain. parse_reviewer_verdict returns HOLD, which Atlas's enforcement reads
+as "do not progress; surface for human review or retry".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal
+from uuid import UUID
+
+log = logging.getLogger(__name__)
+
+Verdict = Literal["APPROVE", "HOLD", "REJECT"]
+
+_VALID_VERDICTS: tuple[str, ...] = ("APPROVE", "HOLD", "REJECT")
+# CONCUR is the persona-emitted token; normalise to APPROVE for advance_step.
+_VERDICT_ALIASES: dict[str, Verdict] = {"CONCUR": "APPROVE"}
+# Maximum characters of leading content to scan for the verdict token —
+# bounds the parse cost and prevents pathological inputs from blocking.
+_LEADING_SCAN_CHARS = 64
+
+# Fetcher signature: (atom_id_str) -> atom (AtomV1, dict-like, or None).
+# Kept loose so tests can pass a plain dict and production wires AtomStore.
+FetcherFn = Callable[[str], Any]
+
+
+@dataclass(frozen=True)
+class ReviewerAtom:
+    """Parsed verdict envelope for an atom emitted by a reviewer agent.
+
+    `verdict` is the only field advance_step needs to switch on; `rationale`
+    is the human-readable reason (the atom's content body, minus the leading
+    verdict token); `atom_id` echoes the input for trace correlation; `raw`
+    preserves the underlying atom payload (None when fetch failed).
+    """
+
+    verdict: Verdict
+    rationale: str = ""
+    atom_id: str = ""
+    raw: Any = field(default=None)
+
+
+def _normalize_verdict(token: str) -> Verdict | None:
+    """Return canonical Verdict for token, or None if not recognised."""
+    t = token.strip().upper()
+    if t in _VALID_VERDICTS:
+        return t  # type: ignore[return-value]
+    if t in _VERDICT_ALIASES:
+        return _VERDICT_ALIASES[t]
+    return None
+
+
+def _extract_from_text(content: str) -> tuple[Verdict | None, str]:
+    """Find the leading verdict token in `content` (case-insensitive).
+
+    A leading token is one of APPROVE/HOLD/REJECT/CONCUR at position 0 of the
+    stripped first line, followed by ':' or whitespace. Returns (verdict,
+    rationale) where rationale is the tail after the token+separator. Returns
+    (None, content) when no leading token matches.
+    """
+    if not content:
+        return None, ""
+    head = content.lstrip()[:_LEADING_SCAN_CHARS]
+    first_line = head.split("\n", 1)[0]
+    upper = first_line.upper()
+    for token in (*_VALID_VERDICTS, *_VERDICT_ALIASES.keys()):
+        if upper.startswith(token + ":") or upper.startswith(token + " ") or upper == token:
+            verdict = _normalize_verdict(token)
+            # Strip token + one separator char to recover the rationale.
+            sep_len = len(token) + (1 if len(first_line) > len(token) else 0)
+            rationale = first_line[sep_len:].strip()
+            return verdict, rationale
+    return None, content.strip()
+
+
+def _atom_field(atom: Any, name: str) -> Any:
+    """Read field `name` from an atom that may be a dataclass, dict, or None."""
+    if atom is None:
+        return None
+    if isinstance(atom, dict):
+        return atom.get(name)
+    return getattr(atom, name, None)
+
+
+def _default_fetcher(atom_id: str) -> Any:
+    """Default fetcher — loads AtomStore lazily so the import surface stays
+    light for tests/CI that don't have a DB. Returns None on ANY failure
+    (invalid UUID, missing config, DB unreachable, atom not present)."""
+    try:
+        from uuid import UUID as _UUID  # noqa: PLC0415
+
+        from src.keiracom_system.atomization.atom_store import AtomStore  # noqa: PLC0415
+
+        return AtomStore().get_atom(_UUID(atom_id))
+    except Exception as exc:  # noqa: BLE001 — fetch must never raise
+        log.debug("reviewer_atom: default fetch failed for %s: %s", atom_id, exc)
+        return None
+
+
+def parse_reviewer_verdict(
+    atom_id: str,
+    *,
+    fetcher: FetcherFn | None = None,
+) -> ReviewerAtom:
+    """Fetch the atom for `atom_id` and extract its verdict.
+
+    Resolution order:
+      1. atom['verdict'] / atom.verdict (canonical structured field if a future
+         reviewer atom carries it explicitly).
+      2. Leading token of atom['content'] / atom.content (current persona shape).
+      3. HOLD safe default (fetch failed, no recognisable token).
+
+    `fetcher` is dependency injection — pass a callable for tests; production
+    uses AtomStore.get_atom. Never raises; downstream advance_step is
+    guaranteed a ReviewerAtom.
+    """
+    fetch = fetcher or _default_fetcher
+    try:
+        atom = fetch(atom_id)
+    except Exception as exc:  # noqa: BLE001 — fetcher contract: never escalate
+        log.warning("reviewer_atom: fetcher raised for %s: %s", atom_id, exc)
+        atom = None
+
+    if atom is None:
+        return ReviewerAtom(
+            verdict="HOLD",
+            rationale="atom not found or fetch failed",
+            atom_id=atom_id,
+            raw=None,
+        )
+
+    # 1. Explicit verdict field wins.
+    explicit = _atom_field(atom, "verdict")
+    if isinstance(explicit, str):
+        verdict = _normalize_verdict(explicit)
+        if verdict is not None:
+            rationale = _atom_field(atom, "rationale") or _atom_field(atom, "content") or ""
+            return ReviewerAtom(
+                verdict=verdict,
+                rationale=str(rationale).strip(),
+                atom_id=atom_id,
+                raw=atom,
+            )
+
+    # 2. Leading token of content.
+    content = _atom_field(atom, "content")
+    if isinstance(content, str):
+        verdict, rationale = _extract_from_text(content)
+        if verdict is not None:
+            return ReviewerAtom(
+                verdict=verdict,
+                rationale=rationale,
+                atom_id=atom_id,
+                raw=atom,
+            )
+
+    # 3. Safe default.
+    return ReviewerAtom(
+        verdict="HOLD",
+        rationale="no verdict field or leading token found",
+        atom_id=atom_id,
+        raw=atom,
+    )

--- a/tests/keiracom_system/chain/test_reviewer_atom.py
+++ b/tests/keiracom_system/chain/test_reviewer_atom.py
@@ -1,0 +1,161 @@
+"""Tests for src/keiracom_system/chain/reviewer_atom.py — ReviewerAtom schema.
+
+Coverage:
+  - parse_reviewer_verdict resolves APPROVE / HOLD / REJECT from explicit
+    `verdict` field on the atom (highest priority).
+  - parse_reviewer_verdict resolves verdict from the leading token of
+    atom.content (persona shape — REJECT:/CONCUR: prefix lines).
+  - CONCUR token normalises to APPROVE.
+  - Missing verdict + non-recognisable content -> HOLD safe default.
+  - Atom not found (fetcher returns None) -> HOLD.
+  - Fetcher raising an exception -> HOLD (never escalates).
+  - Works against both dict-shaped atoms and dataclass-like objects.
+  - Case-insensitive token detection.
+  - Both ':' and ' ' separators after the verdict token.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from src.keiracom_system.chain.reviewer_atom import (
+    ReviewerAtom,
+    parse_reviewer_verdict,
+)
+
+
+def _fetcher(atom: Any):
+    """Tiny fixture-builder: returns a fetcher that always yields `atom`."""
+
+    def f(_atom_id: str) -> Any:
+        return atom
+
+    return f
+
+
+# ─── Explicit verdict field ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("verdict_in", ["APPROVE", "HOLD", "REJECT"])
+def test_explicit_verdict_field_dict(verdict_in: str) -> None:
+    atom = {"verdict": verdict_in, "rationale": f"because {verdict_in.lower()}"}
+    result = parse_reviewer_verdict("atom-1", fetcher=_fetcher(atom))
+    assert result.verdict == verdict_in
+    assert result.rationale == f"because {verdict_in.lower()}"
+    assert result.atom_id == "atom-1"
+    assert result.raw is atom
+
+
+def test_explicit_verdict_field_concur_aliases_to_approve() -> None:
+    atom = {"verdict": "CONCUR", "rationale": "spec satisfied"}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "APPROVE"
+    assert result.rationale == "spec satisfied"
+
+
+def test_explicit_verdict_case_insensitive() -> None:
+    atom = {"verdict": "reject", "content": "ignored"}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "REJECT"
+
+
+def test_explicit_verdict_falls_back_to_content_when_value_invalid() -> None:
+    # invalid 'verdict' string + valid leading token in content => use content.
+    atom = {"verdict": "??", "content": "APPROVE: looks good"}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "APPROVE"
+    assert result.rationale == "looks good"
+
+
+# ─── Leading-token extraction from content ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "leading,expected_verdict",
+    [
+        ("REJECT: No artifact produced.", "REJECT"),
+        ("CONCUR: spec criteria all satisfied", "APPROVE"),
+        ("APPROVE: green-light from atlas", "APPROVE"),
+        ("HOLD: pending Dave decision", "HOLD"),
+        ("reject: lowercase too", "REJECT"),
+        ("APPROVE artifact reachable + spec met", "APPROVE"),  # space sep, not colon
+    ],
+)
+def test_leading_token_from_content(leading: str, expected_verdict: str) -> None:
+    atom = {"content": leading + "\nMore context on the next lines."}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == expected_verdict
+    # rationale is the tail of the FIRST line only
+    assert "\n" not in result.rationale
+
+
+def test_leading_token_dataclass_shape() -> None:
+    @dataclass
+    class FakeAtom:
+        content: str
+        verdict: str | None = None
+
+    atom = FakeAtom(content="REJECT: missing migration", verdict=None)
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "REJECT"
+    assert result.rationale == "missing migration"
+
+
+# ─── Safe-default HOLD ────────────────────────────────────────────────────
+
+
+def test_atom_not_found_defaults_hold() -> None:
+    result = parse_reviewer_verdict("missing-id", fetcher=_fetcher(None))
+    assert result.verdict == "HOLD"
+    assert "fetch failed" in result.rationale or "not found" in result.rationale
+    assert result.raw is None
+
+
+def test_fetcher_raises_defaults_hold() -> None:
+    def boom(_atom_id: str) -> Any:
+        raise RuntimeError("DB down")
+
+    result = parse_reviewer_verdict("a", fetcher=boom)
+    assert result.verdict == "HOLD"
+
+
+def test_empty_content_defaults_hold() -> None:
+    atom = {"content": ""}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "HOLD"
+
+
+def test_content_without_leading_token_defaults_hold() -> None:
+    atom = {"content": "The implementation looks broadly fine to me but I cannot say for sure."}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "HOLD"
+
+
+def test_content_with_verdict_token_mid_sentence_defaults_hold() -> None:
+    # 'REJECT' appears mid-text — only LEADING token counts.
+    atom = {"content": "After consideration we'd REJECT this if it were ours."}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "HOLD"
+
+
+def test_atom_with_no_content_no_verdict_defaults_hold() -> None:
+    atom = {"unrelated_field": "foo"}
+    result = parse_reviewer_verdict("a", fetcher=_fetcher(atom))
+    assert result.verdict == "HOLD"
+
+
+# ─── Returned object contract ─────────────────────────────────────────────
+
+
+def test_reviewer_atom_is_frozen() -> None:
+    r = parse_reviewer_verdict("a", fetcher=_fetcher({"verdict": "APPROVE"}))
+    with pytest.raises(Exception):  # FrozenInstanceError subclass of Exception
+        r.verdict = "REJECT"  # type: ignore[misc]
+
+
+def test_returns_reviewer_atom_dataclass() -> None:
+    r = parse_reviewer_verdict("a", fetcher=_fetcher({"verdict": "HOLD"}))
+    assert isinstance(r, ReviewerAtom)


### PR DESCRIPTION
## Summary

Phase 1 nucleus dispatch from Elliot 2026-06-03. Atlas is wiring `verdict_enforcement` into `advance_step` and needs a reliable way to extract `verdict ∈ {APPROVE, HOLD, REJECT}` from any reviewer atom by `atom_id`.

## New module — `src/keiracom_system/chain/reviewer_atom.py`

- `Verdict = Literal['APPROVE', 'HOLD', 'REJECT']`
- `@dataclass(frozen=True) class ReviewerAtom`: `verdict + rationale + atom_id + raw`
- `parse_reviewer_verdict(atom_id: str, *, fetcher: FetcherFn | None = None) -> ReviewerAtom`

### Resolution order
1. `atom['verdict']` / `atom.verdict` (future-proof — atoms that carry the verdict structurally)
2. Leading token of `atom['content']` / `atom.content` matching `APPROVE|HOLD|REJECT|CONCUR` followed by `:` or whitespace (current persona shape — orion/atlas emit `REJECT:`/`CONCUR:`)
3. **HOLD safe default** — fetch failed, atom None, or no recognisable token

### Vocabulary normalisation
Personas today emit `CONCUR`/`REJECT`. Schema normalises `CONCUR → APPROVE` so `advance_step` has a single three-way enum to switch on.

### Safe-default principle
A missing or malformed verdict NEVER advances the chain. `parse_reviewer_verdict` returns `HOLD`, which Atlas's enforcement should read as "do not progress; surface for human review or retry".

### Default fetcher
Lazy `AtomStore.get_atom(UUID(atom_id))` — tests don't need DB. ANY fetcher exception swallowed to `None → HOLD`.

## Interface for Atlas's `advance_step` wiring

```python
from src.keiracom_system.chain.reviewer_atom import parse_reviewer_verdict

ra = parse_reviewer_verdict(atom_id)        # uses AtomStore in prod
if ra.verdict == 'APPROVE':  advance_to_next_step()
elif ra.verdict == 'REJECT': halt_chain(reason=ra.rationale)
else:                        hold_for_review()   # HOLD covers fetch fail too
```

## Tests

`tests/keiracom_system/chain/test_reviewer_atom.py` — **21 cases**:
- Explicit `verdict` field: APPROVE/HOLD/REJECT, CONCUR aliases, case-insensitive, invalid value falls through to content
- Leading-token extraction from content: parametrized over both `:` and space separators + lowercase variants
- Dataclass-shaped atom (not just dict)
- Atom not found → HOLD
- Fetcher raises → HOLD (never escalates)
- Empty content → HOLD
- Content without leading token → HOLD
- Mid-sentence `REJECT` token → HOLD (only LEADING token counts; defensive)
- Atom with no content/no verdict → HOLD
- `ReviewerAtom` is frozen (mutation raises)

```
$ python -m pytest tests/keiracom_system/chain/test_reviewer_atom.py -v
21 passed in 0.14s
```

## Test plan

- [x] Syntax + 21/21 test cases pass
- [x] No DB dependency at import time (lazy AtomStore import)
- [x] HOLD default verified for all failure modes
- [ ] Atlas wires `parse_reviewer_verdict` into `advance_step`'s verdict_enforcement
- [ ] Reviewers: aiden + max (author-exclusion → 2/2 NATS concur required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)