### PR TITLE
[ATLAS] feat(v1_chain): Phase 1 verdict-enforcement nucleus — REJECT/HOLD halts + bounded loop

### DIFF
--- a/src/keiracom_system/chain/v1_chain_orchestrator.py
+++ b/src/keiracom_system/chain/v1_chain_orchestrator.py
@@ -110,6 +110,17 @@ _DISPATCHER_URL = os.environ.get("DISPATCHER_URL", "http://127.0.0.1:4001")
 # load-bearing for the V1 battery.
 _TASK_COST_CEILING_AUD = float(os.environ.get("V1_TASK_COST_CEILING_AUD", "10.00"))
 
+# Verdict-enforcement nucleus (Phase 1 — atlas-verdict-enforcement-phase1).
+# Reviewer steps return a verdict atom; REJECT/HOLD halts forward progression
+# and re-dispatches aiden_plan with the reviewer's context as the loop brief.
+# Bounded retries: after V1_VERDICT_MAX_RETRIES iterations the chain escalates
+# to Dave via /dispatcher/verdict_halt + state=halted_max_retries. GOV-12: the
+# runtime conditional lives in advance_step below — this is not a comment-only
+# enforcement.
+REVIEWER_STEPS: frozenset[str] = frozenset({"max_challenge", "orion_spec", "atlas_safety"})
+VERDICT_HALT_SET: frozenset[str] = frozenset({"REJECT", "HOLD"})
+V1_VERDICT_MAX_RETRIES = int(os.environ.get("V1_VERDICT_MAX_RETRIES", "3"))
+
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
@@ -210,6 +221,71 @@ def _post_ceiling_breach(
         )
     except Exception:  # noqa: BLE001 — must not break halt-state save
         log.warning("ceiling_breach notify: unexpected error for chain=%s", chain_id, exc_info=True)
+
+
+def _post_verdict_halt(
+    entry: dict,
+    chain_id: str,
+    rejecting_step: str,
+    verdict: str,
+    retry_count: int,
+    *,
+    escalated: bool,
+    verdict_reason: str | None = None,
+    dispatcher_url: str = _DISPATCHER_URL,
+) -> None:
+    """Phase 1 verdict-enforcement notify — POST to /dispatcher/verdict_halt.
+
+    Fired in two cases:
+    - escalated=False: chain looped back to aiden_plan with reviewer context.
+      One #ceo line per loop iteration so Dave can see the retry chain.
+    - escalated=True: retry budget exhausted (>= V1_VERDICT_MAX_RETRIES) —
+      chain is halted permanently and needs Dave's call.
+
+    Fail-open: dispatcher unreachable / non-2xx is logged + swallowed. A notify
+    failure must NEVER block the halt-state save (mirrors _post_ceiling_breach).
+    """
+    import urllib.error  # noqa: PLC0415
+    import urllib.request  # noqa: PLC0415
+
+    payload = json.dumps(
+        {
+            "task_id": entry.get("task_id") or "?",
+            "chain_id": chain_id,
+            "brief": entry.get("brief") or "(no brief)",
+            "rejecting_step": rejecting_step,
+            "verdict": verdict,
+            "verdict_reason": verdict_reason or "",
+            "retry_count": retry_count,
+            "max_retries": V1_VERDICT_MAX_RETRIES,
+            "escalated": escalated,
+            "steps_done": list(entry.get("steps_done") or []),
+            "rejections": list(entry.get("rejections") or []),
+        }
+    ).encode()
+    url = f"{dispatcher_url.rstrip('/')}/dispatcher/verdict_halt"
+    try:
+        req = urllib.request.Request(
+            url, data=payload, headers={"Content-Type": "application/json"}, method="POST"
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 — fixed loopback host
+            log.info(
+                "verdict_halt notify: dispatcher status=%d chain=%s step=%s verdict=%s "
+                "retry=%d/%d escalated=%s",
+                resp.status,
+                chain_id,
+                rejecting_step,
+                verdict,
+                retry_count,
+                V1_VERDICT_MAX_RETRIES,
+                escalated,
+            )
+    except (urllib.error.URLError, OSError):
+        log.warning(
+            "verdict_halt notify: dispatcher unreachable for chain=%s", chain_id, exc_info=True
+        )
+    except Exception:  # noqa: BLE001 — must not break halt-state save
+        log.warning("verdict_halt notify: unexpected error for chain=%s", chain_id, exc_info=True)
 
 
 def _post_chain_complete(
@@ -462,6 +538,8 @@ def advance_step(
     completed_step: str,
     atom_id: str,
     *,
+    verdict: str | None = None,
+    verdict_reason: str | None = None,
     clock: Callable[[], float] = time.time,
 ) -> list[dict]:
     """Record a step completion and dispatch the next step(s).
@@ -470,12 +548,21 @@ def advance_step(
         chain_id: Identifies the chain in the state file.
         completed_step: The step that just finished (e.g. "aiden_plan").
         atom_id: The atom_id returned by the completing agent for this step.
+        verdict: Optional reviewer verdict. When ``completed_step`` is a
+            reviewer step (max_challenge, orion_spec, atlas_safety) and the
+            verdict is REJECT or HOLD, the chain halts forward progression and
+            re-dispatches aiden_plan with the reviewer's context as the loop
+            brief. Bounded by V1_VERDICT_MAX_RETRIES — after that the chain
+            escalates to Dave (state=halted_max_retries). None / any other
+            value = no enforcement (clean advance).
+        verdict_reason: Optional one-liner the reviewer attaches to a non-clean
+            verdict. Surfaced in the loop brief and the #ceo halt post.
         clock: Injectable for tests.
 
     Returns:
         List of envelope dicts that were dispatched (empty list if no dispatch
-        occurred — either the chain is waiting on parallel partners, or it has
-        reached ``complete``).
+        occurred — either the chain is waiting on parallel partners, has
+        reached ``complete``, or hit the retry-budget escalation).
     """
     state = _load_state()
     entry = state.get(chain_id)
@@ -502,6 +589,100 @@ def advance_step(
         entry["pending"].remove(completed_step)
 
     dispatched: list[dict] = []
+
+    # Phase 1 verdict-enforcement nucleus. Runtime conditional (GOV-12):
+    # if a reviewer step returned REJECT or HOLD, halt forward progression
+    # and either (a) re-dispatch aiden_plan with the reviewer's context as a
+    # loop brief, or (b) escalate to Dave when the retry budget is exhausted.
+    # Must run BEFORE the ceiling check + fan-out so a rejecting parallel
+    # partner cannot trigger further dispatches downstream.
+    normalized_verdict = str(verdict).strip().upper() if verdict else ""
+    if completed_step in REVIEWER_STEPS and normalized_verdict in VERDICT_HALT_SET:
+        retries_so_far = int(entry.get("retry_count", 0) or 0)
+        rejections = list(entry.get("rejections") or [])
+        rejections.append(
+            {
+                "step": completed_step,
+                "atom_id": atom_id,
+                "verdict": normalized_verdict,
+                "reason": verdict_reason or "",
+                "loop_at": retries_so_far,
+                "ts": clock(),
+            }
+        )
+        entry["rejections"] = rejections
+        # Cancel any in-flight parallel partner. We can't recall an already
+        # published NATS envelope, but clearing pending here prevents the next
+        # advance_step (from the partner's later completion) from falling
+        # through to the "last parallel step" branch and marking complete.
+        entry["pending"] = []
+
+        if retries_so_far >= V1_VERDICT_MAX_RETRIES:
+            # Retry budget exhausted — halt permanently and escalate.
+            entry["current_step"] = "halted_max_retries"
+            entry["verdict_halt"] = {
+                "rejecting_step": completed_step,
+                "verdict": normalized_verdict,
+                "reason": verdict_reason or "",
+                "retry_count": retries_so_far,
+                "max_retries": V1_VERDICT_MAX_RETRIES,
+                "escalated": True,
+            }
+            try:
+                _post_verdict_halt(
+                    entry,
+                    chain_id,
+                    completed_step,
+                    normalized_verdict,
+                    retries_so_far,
+                    escalated=True,
+                    verdict_reason=verdict_reason,
+                )
+            except Exception:  # noqa: BLE001 — must not break halt-state save
+                log.warning(
+                    "v1_chain verdict-halt(escalated): post raised for chain=%s",
+                    chain_id,
+                    exc_info=True,
+                )
+            _save_state(state)
+            return []
+
+        # Within retry budget — halt forward progression and loop back to
+        # aiden_plan with the rejecter's atom + reason as the brief context.
+        entry["retry_count"] = retries_so_far + 1
+        entry["current_step"] = "aiden_plan"
+        # Fresh slate for the next iteration. atom_ids per step is last-write-
+        # wins (dict) so we leave the keys alone — the rejection list above is
+        # the authoritative history.
+        entry["steps_done"] = []
+        loop_brief = (
+            f"{entry.get('brief') or ''}\n\n"
+            f"[verdict loop {retries_so_far + 1}/{V1_VERDICT_MAX_RETRIES}] "
+            f"Reviewer {completed_step} returned {normalized_verdict}. "
+            f"Reason: {verdict_reason or '(none given)'}. "
+            f"Prior atom: {atom_id}. Re-plan addressing this feedback."
+        )
+        env = _build_envelope(entry["task_id"], chain_id, "aiden_plan", atom_id, loop_brief, clock)
+        _publish_envelope(env, "aiden")
+        dispatched.append(env)
+        try:
+            _post_verdict_halt(
+                entry,
+                chain_id,
+                completed_step,
+                normalized_verdict,
+                retries_so_far + 1,
+                escalated=False,
+                verdict_reason=verdict_reason,
+            )
+        except Exception:  # noqa: BLE001 — must not break loop-state save
+            log.warning(
+                "v1_chain verdict-halt(loop): post raised for chain=%s",
+                chain_id,
+                exc_info=True,
+            )
+        _save_state(state)
+        return dispatched
 
     # V1-battery Gate 1 — per-task A$10 ceiling. Query SUM(cost_aud) for
     # this task_id; halt + post #ceo if exceeded. Runs BEFORE the dispatch
@@ -603,6 +784,8 @@ async def _advance_step_async(
     completed_step: str,
     atom_id: str,
     *,
+    verdict: str | None = None,
+    verdict_reason: str | None = None,
     clock: Callable[[], float] = time.time,
 ) -> list[dict]:
     """Async entrypoint for the V1 consumer loop (Atlas oevr).
@@ -620,9 +803,19 @@ async def _advance_step_async(
     event loop, which runs single-threaded: only one coroutine can observe
     `complete_posted is False` and flip it, so only one post fires.
     Race fixed 2026-05-30 (Elliot diagnosis).
+
+    ``verdict`` / ``verdict_reason`` are forwarded verbatim into advance_step
+    so the Phase 1 verdict-enforcement nucleus can halt + loop on REJECT/HOLD
+    from a reviewer step.
     """
     envelopes = await asyncio.to_thread(
-        advance_step, chain_id, completed_step, atom_id, clock=clock
+        advance_step,
+        chain_id,
+        completed_step,
+        atom_id,
+        verdict=verdict,
+        verdict_reason=verdict_reason,
+        clock=clock,
     )
     # Single-threaded serialisation point — only one coroutine wins the flip.
     state = _load_state()
@@ -677,8 +870,18 @@ async def _consumer_handle_envelope_async(envelope: dict) -> list[dict]:
         if step is None:
             log.warning("v1_chain consumer: unknown from_callsign=%s — skip", from_callsign)
             return []
+        # Phase 1 verdict-enforcement (atlas-verdict-enforcement-phase1): the
+        # handoff envelope may carry a reviewer's verdict + one-liner reason.
+        # Forwarded verbatim — advance_step's runtime conditional decides
+        # whether to halt+loop or advance.
+        verdict = envelope.get("verdict")
+        verdict_reason = envelope.get("verdict_reason")
         envelopes = await _advance_step_async(
-            chain_id=task_id, completed_step=step, atom_id=atom_id
+            chain_id=task_id,
+            completed_step=step,
+            atom_id=atom_id,
+            verdict=verdict,
+            verdict_reason=verdict_reason,
         )
         log.info(
             "v1_chain consumer: chain=%s step=%s -> %d dispatch(es)",

--- a/tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py
+++ b/tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py
@@ -1,0 +1,328 @@
+"""Phase 1 verdict-enforcement tests for v1_chain_orchestrator.advance_step.
+
+Covers the runtime conditional (GOV-12) that halts forward progression on
+any reviewer step returning REJECT or HOLD, loops the chain back to
+aiden_plan with the reviewer's context, and escalates after the retry budget
+(V1_VERDICT_MAX_RETRIES) is exhausted.
+
+Reviewer steps under enforcement: max_challenge, orion_spec, atlas_safety.
+All other completions advance / behave as before — verified by the
+"clean advance still works" regression block.
+
+ref: atlas-verdict-enforcement-phase1
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.keiracom_system.chain import v1_chain_orchestrator as orch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state_and_capture(tmp_path, monkeypatch):
+    """Redirect STATE_FILE into tmp_path; capture _publish_envelope + posts.
+
+    Yields a dict of (published_envelopes, halt_posts) so each test can
+    assert on what advance_step asked downstream to do without any real
+    NATS / urllib traffic.
+    """
+    state_path = tmp_path / "v1_chain_state.json"
+    monkeypatch.setattr(orch, "STATE_FILE", state_path)
+
+    published: list[tuple[dict, str]] = []
+    monkeypatch.setattr(
+        orch, "_publish_envelope", lambda env, role: published.append((env, role)) or True
+    )
+
+    halt_posts: list[dict[str, Any]] = []
+    monkeypatch.setattr(
+        orch,
+        "_post_verdict_halt",
+        lambda entry, chain_id, step, verdict, retry, *, escalated, verdict_reason=None, **_: (
+            halt_posts.append(
+                {
+                    "chain_id": chain_id,
+                    "step": step,
+                    "verdict": verdict,
+                    "retry": retry,
+                    "escalated": escalated,
+                    "reason": verdict_reason,
+                    "state_snapshot_current_step": entry.get("current_step"),
+                }
+            )
+        ),
+    )
+
+    # The ceiling check tries to read DATABASE_URL — keep it short-circuited.
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    yield {"published": published, "halt_posts": halt_posts, "state_path": state_path}
+
+
+def _seed_chain(state_path: Path, chain_id: str = "T1", brief: str = "do the thing") -> None:
+    state_path.write_text(
+        json.dumps(
+            {
+                chain_id: {
+                    "chain_id": chain_id,
+                    "task_id": chain_id,
+                    "brief": brief,
+                    "started_ts": 0.0,
+                    "current_step": "aiden_plan",
+                    "steps_done": [],
+                    "atom_ids": {},
+                    "pending": [],
+                }
+            }
+        )
+    )
+
+
+def _state(state_path: Path, chain_id: str = "T1") -> dict:
+    return json.loads(state_path.read_text())[chain_id]
+
+
+# ---------------------------------------------------------------------------
+# Harness 1 — REJECT halts and loops
+# ---------------------------------------------------------------------------
+
+
+def test_max_challenge_reject_halts_and_loops_to_aiden(_isolated_state_and_capture):
+    """max REJECT must NOT dispatch nova_build; must re-dispatch aiden_plan."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+
+    # Walk aiden_plan → max_challenge with REJECT on the max hop.
+    orch.advance_step("T1", "aiden_plan", "atom-aiden-1")
+    cap["published"].clear()  # discard the aiden→max dispatch from the clean leg
+
+    dispatched = orch.advance_step(
+        "T1",
+        "max_challenge",
+        "atom-max-1",
+        verdict="REJECT",
+        verdict_reason="plan missing rollback path",
+    )
+
+    # No nova_build dispatch — only the loop-back aiden_plan envelope.
+    assert len(dispatched) == 1
+    assert dispatched[0]["chain_step"] == "aiden_plan"
+    assert all(role == "aiden" for _env, role in cap["published"])
+
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "aiden_plan"
+    assert entry["retry_count"] == 1
+    assert entry["steps_done"] == []  # cleared for the next loop iteration
+    assert len(entry["rejections"]) == 1
+    rej = entry["rejections"][0]
+    assert rej["step"] == "max_challenge"
+    assert rej["verdict"] == "REJECT"
+    assert rej["reason"] == "plan missing rollback path"
+
+    # Exactly one halt-post (loop, not escalated).
+    assert len(cap["halt_posts"]) == 1
+    assert cap["halt_posts"][0]["escalated"] is False
+    assert cap["halt_posts"][0]["retry"] == 1
+
+
+def test_orion_spec_hold_halts_chain(_isolated_state_and_capture):
+    """orion_spec HOLD during parallel phase halts + loops, no chain_complete."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+
+    # Walk to the parallel stage: aiden → max → nova.
+    orch.advance_step("T1", "aiden_plan", "a1")
+    orch.advance_step("T1", "max_challenge", "m1", verdict="APPROVE")
+    orch.advance_step("T1", "nova_build", "n1")
+    cap["published"].clear()
+    cap["halt_posts"].clear()
+
+    # orion_spec returns HOLD — chain must halt + loop, atlas_safety becomes
+    # an in-flight orphan we cannot recall but the chain is no longer
+    # "waiting on" it.
+    dispatched = orch.advance_step(
+        "T1", "orion_spec", "o1", verdict="HOLD", verdict_reason="spec ambiguous"
+    )
+
+    assert len(dispatched) == 1
+    assert dispatched[0]["chain_step"] == "aiden_plan"
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "aiden_plan"
+    assert entry["pending"] == []  # parallel-partner wait cleared
+    assert entry["retry_count"] == 1
+    assert entry["rejections"][-1]["verdict"] == "HOLD"
+
+
+def test_atlas_safety_reject_halts_chain(_isolated_state_and_capture):
+    """atlas_safety REJECT halts + loops just like orion_spec."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+    orch.advance_step("T1", "aiden_plan", "a1")
+    orch.advance_step("T1", "max_challenge", "m1", verdict="APPROVE")
+    orch.advance_step("T1", "nova_build", "n1")
+    cap["published"].clear()
+    cap["halt_posts"].clear()
+
+    dispatched = orch.advance_step(
+        "T1", "atlas_safety", "s1", verdict="REJECT", verdict_reason="unsafe shell call"
+    )
+    assert len(dispatched) == 1
+    assert dispatched[0]["chain_step"] == "aiden_plan"
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "aiden_plan"
+    assert entry["retry_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Harness 2 — clean APPROVE still advances
+# ---------------------------------------------------------------------------
+
+
+def test_clean_advance_max_to_nova_still_works(_isolated_state_and_capture):
+    """Regression: APPROVE verdict (and None) must NOT halt the chain."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+    orch.advance_step("T1", "aiden_plan", "a1")
+    cap["published"].clear()
+    cap["halt_posts"].clear()
+
+    dispatched = orch.advance_step("T1", "max_challenge", "m1", verdict="APPROVE")
+
+    assert len(dispatched) == 1
+    assert dispatched[0]["chain_step"] == "nova_build"
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "nova_build"
+    assert entry.get("retry_count", 0) == 0
+    assert not entry.get("rejections")
+    assert cap["halt_posts"] == []
+
+
+def test_no_verdict_kwarg_preserves_legacy_advance(_isolated_state_and_capture):
+    """advance_step called without verdict= must behave exactly as before."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+    orch.advance_step("T1", "aiden_plan", "a1")
+    cap["published"].clear()
+
+    dispatched = orch.advance_step("T1", "max_challenge", "m1")  # no verdict kwarg
+    assert len(dispatched) == 1
+    assert dispatched[0]["chain_step"] == "nova_build"
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "nova_build"
+
+
+def test_verdict_on_non_reviewer_step_is_ignored(_isolated_state_and_capture):
+    """verdict=REJECT on aiden_plan or nova_build must NOT halt — only
+    reviewer steps trigger enforcement."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+
+    # aiden_plan with REJECT should still dispatch max_challenge normally.
+    dispatched = orch.advance_step("T1", "aiden_plan", "a1", verdict="REJECT")
+    assert len(dispatched) == 1
+    assert dispatched[0]["chain_step"] == "max_challenge"
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "max_challenge"
+    assert not entry.get("rejections")
+
+
+# ---------------------------------------------------------------------------
+# Harness 3 — bounded retries escalate
+# ---------------------------------------------------------------------------
+
+
+def test_max_retries_escalates_to_halted_state(_isolated_state_and_capture, monkeypatch):
+    """After V1_VERDICT_MAX_RETRIES (default 3) reviewer rejections, the
+    chain must halt permanently and post an escalation."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+
+    # 3 REJECT loops: each loops retry_count 0→1, 1→2, 2→3.
+    for i in range(orch.V1_VERDICT_MAX_RETRIES):
+        orch.advance_step("T1", "aiden_plan", f"a{i}")
+        dispatched = orch.advance_step(
+            "T1",
+            "max_challenge",
+            f"m{i}",
+            verdict="REJECT",
+            verdict_reason=f"loop {i + 1}",
+        )
+        assert dispatched, f"loop {i + 1} should re-dispatch aiden_plan"
+        assert dispatched[0]["chain_step"] == "aiden_plan"
+
+    entry = _state(cap["state_path"])
+    assert entry["retry_count"] == orch.V1_VERDICT_MAX_RETRIES
+
+    # The next rejection exhausts the budget → escalation, no dispatch.
+    cap["published"].clear()
+    dispatched = orch.advance_step(
+        "T1",
+        "aiden_plan",
+        "a_final",
+    )
+    assert dispatched and dispatched[0]["chain_step"] == "max_challenge"
+    cap["published"].clear()
+
+    dispatched = orch.advance_step(
+        "T1",
+        "max_challenge",
+        "m_final",
+        verdict="REJECT",
+        verdict_reason="budget-exhaust",
+    )
+    assert dispatched == []
+
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "halted_max_retries"
+    assert entry["verdict_halt"]["escalated"] is True
+    assert entry["verdict_halt"]["retry_count"] == orch.V1_VERDICT_MAX_RETRIES
+
+    # Final halt post is the escalation one.
+    escalations = [p for p in cap["halt_posts"] if p["escalated"]]
+    assert len(escalations) == 1
+    assert escalations[0]["retry"] == orch.V1_VERDICT_MAX_RETRIES
+
+
+# ---------------------------------------------------------------------------
+# Harness 4 — case-insensitive verdict normalisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw_verdict", ["reject", " Reject ", "HOLD", "hold", "Hold"])
+def test_verdict_token_case_and_whitespace_normalised(_isolated_state_and_capture, raw_verdict):
+    """Reviewer verdicts must be case + whitespace insensitive."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+    orch.advance_step("T1", "aiden_plan", "a1")
+    cap["published"].clear()
+    cap["halt_posts"].clear()
+
+    dispatched = orch.advance_step("T1", "max_challenge", "m1", verdict=raw_verdict)
+    assert dispatched and dispatched[0]["chain_step"] == "aiden_plan"
+    entry = _state(cap["state_path"])
+    assert entry["rejections"][-1]["verdict"] in orch.VERDICT_HALT_SET
+
+
+def test_unknown_verdict_token_does_not_halt(_isolated_state_and_capture):
+    """An unrecognised verdict string (e.g. 'MAYBE') is treated as
+    'no enforcement' — the chain advances normally."""
+    cap = _isolated_state_and_capture
+    _seed_chain(cap["state_path"])
+    orch.advance_step("T1", "aiden_plan", "a1")
+    cap["published"].clear()
+    cap["halt_posts"].clear()
+
+    dispatched = orch.advance_step("T1", "max_challenge", "m1", verdict="MAYBE")
+    assert dispatched and dispatched[0]["chain_step"] == "nova_build"
+    entry = _state(cap["state_path"])
+    assert entry["current_step"] == "nova_build"
+    assert not entry.get("rejections")


### PR DESCRIPTION
## Summary

Phase 1 nucleus per the dispatch brief (ref: `atlas-verdict-enforcement-phase1`).
Adds runtime enforcement (GOV-12 — code, not a comment) to `advance_step` so a
reviewer step returning `REJECT` or `HOLD` no longer falls through to the next
hop. The chain halts forward progression and re-dispatches `aiden_plan` with
the rejecter's atom + reason as the loop brief.

Reviewer steps under enforcement: `max_challenge`, `orion_spec`, `atlas_safety`.

## Behaviour

| Reviewer verdict | Behaviour |
|---|---|
| `APPROVE` / no verdict | Chain advances to next step (legacy path, unchanged) |
| `REJECT` / `HOLD` (reviewer step) | Forward dispatch suppressed; aiden_plan re-dispatched with loop brief; `retry_count` ++ |
| `REJECT` / `HOLD` on non-reviewer step | Ignored (no-op) |
| `REJECT` / `HOLD` after `V1_VERDICT_MAX_RETRIES` (default 3) iterations | Permanent halt — `state.current_step = "halted_max_retries"`, `_post_verdict_halt(..., escalated=True)` |
| Case + whitespace (`reject`, ` Reject `, `HOLD`, etc.) | Normalised |
| Unknown token (`MAYBE`) | Treated as `None` — chain advances |

## Files

- `src/keiracom_system/chain/v1_chain_orchestrator.py`:
  - Module constants: `REVIEWER_STEPS`, `VERDICT_HALT_SET`, `V1_VERDICT_MAX_RETRIES`.
  - `_post_verdict_halt` helper (mirrors `_post_ceiling_breach` POST shape, target `/dispatcher/verdict_halt`).
  - `advance_step` gains `verdict=None, verdict_reason=None` kwargs (backwards-compatible).
  - The halt+loop block runs BEFORE the Gate 1 ceiling check and BEFORE the dispatch fan-out, so a rejecting parallel partner (e.g. `orion_spec` `HOLD` while `atlas_safety` is still in flight) cannot trigger downstream work.
  - `_advance_step_async` + `_consumer_handle_envelope_async` forward `verdict` / `verdict_reason` verbatim from the envelope.

- `tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py` — 13 tests.

## Coordination with PR #1417 (Scout — ReviewerAtom parser)

Scout's `parse_reviewer_verdict(atom_id) -> ReviewerAtom` is the upstream
extraction primitive. This PR lands the orchestrator-side enforcement so
both PRs are independently mergeable. The wire-up — calling
`parse_reviewer_verdict` inside the handoff publisher (`agent_cold_start`)
and attaching the result to the envelope as `verdict` + `verdict_reason` —
is a follow-up.

## Verbatim test output (exit 0)

```
$ PYTHONPATH=/home/elliotbot/clawd/Agency_OS python3 -m pytest tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py -v --no-header
============================= test session starts ==============================
collecting ... collected 13 items

tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_max_challenge_reject_halts_and_loops_to_aiden PASSED [  7%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_orion_spec_hold_halts_chain PASSED [ 15%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_atlas_safety_reject_halts_chain PASSED [ 23%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_clean_advance_max_to_nova_still_works PASSED [ 30%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_no_verdict_kwarg_preserves_legacy_advance PASSED [ 38%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_verdict_on_non_reviewer_step_is_ignored PASSED [ 46%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_max_retries_escalates_to_halted_state PASSED [ 53%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_verdict_token_case_and_whitespace_normalised[reject] PASSED [ 61%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_verdict_token_case_and_whitespace_normalised[ Reject ] PASSED [ 69%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_verdict_token_case_and_whitespace_normalised[HOLD] PASSED [ 76%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_verdict_token_case_and_whitespace_normalised[hold] PASSED [ 84%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_verdict_token_case_and_whitespace_normalised[Hold] PASSED [ 92%]
tests/keiracom_system/chain/test_v1_chain_orchestrator_verdict.py::test_unknown_verdict_token_does_not_halt PASSED [100%]

============================== 13 passed in 0.13s ==============================
```

Plus full regression on the existing 38-test orchestrator suite — combined `51 passed in 0.40s`.

## Lint / format

`ruff check` and `ruff format --check` both green on both files.

## Out-of-scope (deliberately)

- Wiring `parse_reviewer_verdict` into the publisher side — separate PR.
- Implementing `/dispatcher/verdict_halt` receiver endpoint — `_post_verdict_halt` is already fail-open (mirrors `_post_ceiling_breach`), so the orchestrator works correctly whether the endpoint exists yet or not.
- Cleanup of in-flight orphan parallel partner completions (we clear `pending` on halt, but a NATS envelope already in flight will arrive after; the orchestrator handles it gracefully — the late arrival hits the cleared `steps_done` list as a new entry and idle-waits, no double-dispatch).

🤖 Atlas — Tier A build clone (engineering execution)