### PR TITLE
[SCOUT] fix(reviewer_atom): ruff UP035 Callable + F401 unused UUID — unblock main CI

### DIFF
--- a/src/keiracom_system/chain/reviewer_atom.py
+++ b/src/keiracom_system/chain/reviewer_atom.py
@@ -27,9 +27,9 @@ as "do not progress; surface for human review or retry".
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Literal
-from uuid import UUID
+from typing import Any, Literal
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Hotfix: Backend Lint (Ruff) failing on `main` after PR #1417 merge. Two one-line import fixes.

## Errors

- **UP035** line 31 — `from typing import Callable` deprecated in 3.9+ → `from collections.abc import Callable`
- **F401** line 32 — `from uuid import UUID` unused at module top (UUID is imported locally inside `_default_fetcher`'s lazy block as `_UUID`)

## Fix

```diff
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Callable, Literal
-from uuid import UUID
+from typing import Any, Literal
```

## Verifications

```
$ python -m ruff check src/keiracom_system/chain/reviewer_atom.py
All checks passed!

$ python -m ruff format --check src/keiracom_system/chain/reviewer_atom.py
1 file already formatted

$ python -m pytest tests/keiracom_system/chain/test_reviewer_atom.py -q
21 passed in 0.12s
```

No behavioural change — same 21/21 tests pass. ref: scout-reviewer-atom-ruff-hotfix

## Test plan

- [x] Ruff check passes
- [x] Ruff format check passes
- [x] All 21 unit tests still pass
- [ ] Reviewers: aiden + max (author-exclusion → 2/2 NATS concur required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)