### PR TITLE
[ATLAS] spike(proof_gate_ledger): mutation harness for fn_verify_before_proven Check A — 3 mutants KILLED

### DIFF
--- a/scripts/spike/mutation_test_check_a.py
+++ b/scripts/spike/mutation_test_check_a.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Mutation harness for fn_verify_before_proven Check A (cmd_mismatch).
+
+Spike per ceo:keiracom:proof_integration_plan_v1 → spike_mutation_gate
+(ref: atlas-spike-mutation-gate).
+
+WHY A CUSTOM HARNESS (not mutmut / cosmic-ray):
+
+  mutmut and cosmic-ray mutate Python source. The verifier we care about
+  is a PL/pgSQL trigger function (fn_verify_before_proven) living in
+  Postgres — mutating the Python TEST file would prove nothing about
+  whether the gate itself bites. So this harness mutates the PL/pgSQL
+  body in-place inside the harness's own transaction, runs targeted
+  negative-path probes against the mutated trigger, then ROLLS BACK the
+  entire transaction so the production fn body never changes from the
+  outside world's perspective.
+
+SAFETY MODEL:
+
+  The harness runs in ONE long-lived transaction (autocommit=False).
+  Each mutant is applied via CREATE OR REPLACE FUNCTION inside that tx.
+  Postgres DDL within a transaction is visible only to the executing tx
+  until commit — concurrent connections continue to see the original fn
+  the entire time. The harness NEVER commits — `finally: conn.rollback()`
+  discards all mutant DDL and any fixture rows. Zero production impact.
+
+  Test fixtures (gate_roadmap row, tool_call_log row, gate_proof_runs
+  row) are wrapped in SAVEPOINTs so an inner check_violation from the
+  mutant doesn't break the harness's outer tx state.
+
+ACCEPTANCE CRITERION (directive verbatim):
+
+  "the test asserting the gate REJECTS a non-matching run_cmd must KILL
+  the mutant that represents today's shape-only flip — i.e. a mutant
+  that removes or weakens Check A so that a pytest-only attestation
+  (run_cmd='pytest tests/db/test_proof_gate_ledger.py -v') would be
+  ACCEPTED when the contract requires a different command."
+
+  A mutant is KILLED when the negative test no longer observes
+  "Check A" + "cmd_mismatch" in the error message — either the mutant
+  raised something else (trg_11 dual-attest, Check B substring, etc.)
+  or it didn't raise at all and the UPDATE was accepted.
+
+USAGE:
+
+  source /home/elliotbot/.config/agency-os/.env
+  export TEST_DATABASE_URL="${DATABASE_URL//postgresql+asyncpg/postgresql}"
+  PYTHONPATH=/home/elliotbot/clawd/Agency_OS \\
+      python3 scripts/spike/mutation_test_check_a.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+import uuid
+from typing import Any
+
+import psycopg
+
+CONTRACT = {
+    "check_id": "spike_mutation_check_a",
+    "cmd": "EXACTCMD_FOR_SPIKE",
+    "expected_output_contains": ["SIGNAL_X", "SIGNAL_Y"],
+    "role_sep": {"builder": "atlas", "attester": ["aiden", "max"]},
+    "negative_test_required": True,
+}
+
+# Each scenario provides the run_cmd we will write into the proof_run.
+# UNRELATED — completely different cmd; original raises, M1/M2/M3 all change behaviour.
+# SUPERSET  — run_cmd CONTAINS contract.cmd as a substring; original raises (exact
+#             mismatch), M_substring would accept (contains contract.cmd).
+SCENARIOS: list[tuple[str, str]] = [
+    ("UNRELATED_CMD", "WRONG_CMD_unrelated"),
+    ("SUPERSET_CMD", CONTRACT["cmd"] + " --extra-arg suffix"),
+]
+
+# Targeted mutants of Check A. Each `old` string MUST be unique in the original
+# fn body — if `mutated == original`, the harness flags the mutant as NO_APPLY
+# rather than silently letting it survive.
+MUTANTS: list[dict[str, str]] = [
+    {
+        "id": "M1_invert_distinct_from",
+        "description": "Replace IS DISTINCT FROM with IS NOT DISTINCT FROM (logical inversion).",
+        "old": "IF v_run_cmd IS DISTINCT FROM v_expected_cmd THEN",
+        "new": "IF v_run_cmd IS NOT DISTINCT FROM v_expected_cmd THEN",
+    },
+    {
+        "id": "M2_never_raise",
+        "description": "Replace cmd-mismatch condition with false (no-op the check).",
+        "old": "IF v_run_cmd IS DISTINCT FROM v_expected_cmd THEN",
+        "new": "IF false THEN",
+    },
+    {
+        "id": "M3_substring_match",
+        "description": (
+            "Weaken exact match to substring match — today's shape-only flip "
+            "(allows a pytest-only attestation when contract.cmd happens to be "
+            "a substring of the run_cmd)."
+        ),
+        "old": "IF v_run_cmd IS DISTINCT FROM v_expected_cmd THEN",
+        "new": "IF position(v_expected_cmd IN v_run_cmd) = 0 THEN",
+    },
+]
+
+
+def _run_output_with_signals() -> str:
+    return (
+        "spike mutation run_output padded for >=32 length — "
+        + " ".join(CONTRACT["expected_output_contains"])
+        + " — end"
+    )
+
+
+def _run_negative_probe(
+    conn: psycopg.Connection, scenario_id: str, run_cmd: str
+) -> tuple[str, str | None]:
+    """Set up fixtures + attempt the proven flip — observe the outcome.
+
+    Returns (outcome, message):
+        ("RAISED_CHECK_A", msg) — original Check A behaviour preserved
+        ("RAISED_OTHER",   msg) — some other trigger refused (mutant broke
+                                  Check A, but downstream caught the case
+                                  → still observably KILLED)
+        ("DID_NOT_RAISE",  None) — mutant let the UPDATE through — KILLED
+    """
+    cur = conn.cursor()
+    gate_id = uuid.uuid4()
+    session_uuid = uuid.uuid4()
+    cur.execute("SAVEPOINT spike_probe")
+    try:
+        cur.execute("SET LOCAL agency_os.callsign = 'atlas'")
+        cur.execute(
+            """
+            INSERT INTO public.gate_roadmap (
+                id, component, phase, subphase, proof_gate, proof_gate_contract,
+                status, required_attestation_kind, owner
+            ) VALUES (
+                %s, %s, '0_foundation', 'gates', 'spike mutation fixture',
+                %s::jsonb, 'built', 'binding_reviewer', 'atlas'
+            )
+            """,
+            (gate_id, f"spike_mut_{scenario_id}_{uuid.uuid4().hex[:8]}", json.dumps(CONTRACT)),
+        )
+        cur.execute(
+            """
+            INSERT INTO public.tool_call_log (callsign, session_uuid, tool_name, started_at)
+            VALUES ('aiden', %s, 'spike_mutation', now())
+            """,
+            (session_uuid,),
+        )
+        cur.execute("SET LOCAL agency_os.callsign = 'aiden'")
+        run_output = _run_output_with_signals()
+        sha = hashlib.sha256(f"spike|{scenario_id}|{run_cmd}|{session_uuid}".encode()).hexdigest()
+        cur.execute(
+            """
+            INSERT INTO public.gate_proof_runs (
+                gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+                exit_code, attesting_callsign, attester_session_uuid
+            ) VALUES (
+                %s, 'binding_reviewer', %s, %s, %s, 0, 'aiden', %s
+            )
+            RETURNING id
+            """,
+            (gate_id, run_cmd, run_output, sha, str(session_uuid)),
+        )
+        run_id = cur.fetchone()[0]
+
+        cur.execute("SET LOCAL agency_os.callsign = 'dave'")
+        try:
+            cur.execute(
+                "UPDATE public.gate_roadmap SET status='proven', proof_run_id=%s WHERE id=%s",
+                (run_id, gate_id),
+            )
+            return "DID_NOT_RAISE", None
+        except psycopg.errors.CheckViolation as exc:
+            msg = str(exc).strip()
+            if "Check A" in msg and "cmd_mismatch" in msg:
+                return "RAISED_CHECK_A", msg
+            return "RAISED_OTHER", msg
+    finally:
+        cur.execute("ROLLBACK TO SAVEPOINT spike_probe")
+
+
+def _fetch_original_fn(conn: psycopg.Connection) -> str:
+    cur = conn.cursor()
+    cur.execute("SELECT pg_get_functiondef('fn_verify_before_proven'::regproc)")
+    return cur.fetchone()[0]
+
+
+def main() -> int:
+    dsn = os.environ.get("TEST_DATABASE_URL", "")
+    if not dsn:
+        sys.stderr.write("ERROR: TEST_DATABASE_URL not set.\n")
+        return 2
+
+    conn = psycopg.connect(dsn, autocommit=False)
+    original = _fetch_original_fn(conn)
+
+    print("=" * 78)
+    print("MUTATION HARNESS — fn_verify_before_proven Check A (cmd_mismatch)")
+    print("=" * 78)
+    print(f"Original fn body length: {len(original)} chars")
+    print("Tx isolation: harness runs in a single uncommitted transaction; ")
+    print("              DDL mutants are visible only to this tx and are ")
+    print("              discarded by the final ROLLBACK.")
+    print()
+
+    cur = conn.cursor()
+    results: list[dict[str, Any]] = []
+
+    try:
+        # ── Baseline ────────────────────────────────────────────────────────
+        print("--- BASELINE (original fn) ---")
+        baseline_outcomes = []
+        for scen, cmd in SCENARIOS:
+            outcome, msg = _run_negative_probe(conn, scen, cmd)
+            baseline_outcomes.append((scen, outcome, msg))
+            print(f"  scenario={scen:14s}  outcome={outcome}")
+            print(f"    message: {(msg or '')[:240]}")
+        baseline_ok = all(o[1] == "RAISED_CHECK_A" for o in baseline_outcomes)
+        print(f"\nBaseline pass (all RAISED_CHECK_A): {baseline_ok}")
+
+        # ── Each mutant ─────────────────────────────────────────────────────
+        for m in MUTANTS:
+            print(f"\n--- MUTANT {m['id']} ---")
+            print(f"    {m['description']}")
+            mutated = original.replace(m["old"], m["new"])
+            if mutated == original:
+                print("    WARNING: mutant did not apply (old text not found in fn body).")
+                results.append({"id": m["id"], "status": "NO_APPLY", "scenarios": []})
+                continue
+
+            cur.execute(mutated)
+
+            scenario_outcomes: list[tuple[str, str, str | None]] = []
+            for scen, cmd in SCENARIOS:
+                outcome, msg = _run_negative_probe(conn, scen, cmd)
+                scenario_outcomes.append((scen, outcome, msg))
+                print(f"    scenario={scen:14s}  outcome={outcome}")
+                print(f"      message: {(msg or '')[:240]}")
+
+            # Mutant is KILLED iff the negative test no longer observes Check A
+            # on AT LEAST ONE scenario (the test that previously detected this
+            # class of weakening).
+            killed = any(o[1] != "RAISED_CHECK_A" for o in scenario_outcomes)
+            results.append(
+                {
+                    "id": m["id"],
+                    "description": m["description"],
+                    "status": "KILLED" if killed else "SURVIVED",
+                    "scenarios": scenario_outcomes,
+                }
+            )
+
+            # Restore original within the tx so the next mutant starts clean.
+            cur.execute(original)
+
+    finally:
+        # Hard rollback — discard every DDL change + every fixture insert.
+        conn.rollback()
+        conn.close()
+
+    # ── Report ──────────────────────────────────────────────────────────────
+    print("\n" + "=" * 78)
+    print("MUTATION REPORT")
+    print("=" * 78)
+    print(f"{'Mutant ID':32s}  {'Status':10s}  Scenario outcomes")
+    print("-" * 78)
+    for r in results:
+        scen_str = ", ".join(f"{s[0]}={s[1]}" for s in r.get("scenarios", []))
+        print(f"{r['id']:32s}  {r['status']:10s}  {scen_str}")
+
+    n_killed = sum(1 for r in results if r["status"] == "KILLED")
+    n_survived = sum(1 for r in results if r["status"] == "SURVIVED")
+    n_no_apply = sum(1 for r in results if r["status"] == "NO_APPLY")
+    print(
+        f"\nTotal: {n_killed} KILLED, {n_survived} SURVIVED, "
+        f"{n_no_apply} NO_APPLY (out of {len(results)})."
+    )
+    # Exit 0 iff every applied mutant was killed (no survivors).
+    return 0 if n_survived == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/db/test_proof_gate_ledger_spike_mutation.py
+++ b/tests/db/test_proof_gate_ledger_spike_mutation.py
@@ -1,0 +1,92 @@
+"""Spike test: assert the gate KILLS the substring (shape-only) mutant of Check A.
+
+Lives in its own file (NOT in tests/db/test_proof_gate_ledger.py) so the four
+load-bearing dogfood function names in that file remain contract-locked. The
+test below is a regression catch — without it, a future shape-only weakening
+of Check A would slip past the pytest dogfood suite (the existing
+test_negative_cmd_mismatch_raises uses an UNRELATED_CMD shape which a
+position()-based substring check would still happen to reject).
+
+Tested directly against the live trigger via TEST_DATABASE_URL — same opt-in
+convention as the dogfood file (tests/conftest.py rewires DATABASE_URL to a
+fake "test_db" for unit tests, so live-DB tests must read from
+TEST_DATABASE_URL).
+
+ref: atlas-spike-mutation-gate + ceo:keiracom:proof_integration_plan_v1
+"""
+
+from __future__ import annotations
+
+import os
+
+import psycopg
+import pytest
+
+# Reuse the dogfood helpers — they're the canonical fixtures for the live trigger.
+from tests.db.test_proof_gate_ledger import (
+    _CONTRACT,
+    _build_run_output,
+    _connect,
+    _insert_proof_run,
+    _seed_fixture,
+)
+
+_DSN = os.environ.get("TEST_DATABASE_URL", "")
+
+pytestmark = pytest.mark.skipif(
+    not _DSN,
+    reason="TEST_DATABASE_URL not set — spike mutation test skipped",
+)
+
+
+def test_negative_cmd_superset_raises():
+    """run_cmd is a strict SUPERSET of contract.cmd → Check A must still raise.
+
+    Shape-only flip the harness probes (M3_substring_match): an attacker
+    submits a run_cmd that CONTAINS contract.cmd as a substring but is not
+    equal — e.g. ``contract.cmd + " --extra-arg"``.
+
+    Under exact-match Check A: the cmds are not equal → Check A raises.
+    Under substring-match mutant: contract.cmd IS in run_cmd → position > 0
+    → IF position(..) = 0 evaluates FALSE → no raise → downstream catches it
+    via trg_11 dual-attest instead, with a message that lacks "Check A" /
+    "cmd_mismatch" tokens. This test asserts the original exact-match
+    behaviour by demanding those tokens in the error message — so a
+    shape-only flip would make these asserts fail, killing the mutant.
+    """
+    import uuid
+
+    conn = _connect()
+    try:
+        with conn.cursor() as cur:
+            session_uuid = uuid.uuid4()
+            gate_id, _ = _seed_fixture(
+                cur,
+                contract=_CONTRACT,
+                component_suffix=f"SUPERSET_{uuid.uuid4().hex[:8]}",
+                session_uuid=session_uuid,
+            )
+            run_id = _insert_proof_run(
+                cur,
+                gate_id=gate_id,
+                # Strict superset — contains contract.cmd but is not equal.
+                run_cmd=_CONTRACT["cmd"] + " --extra-arg suffix",
+                run_output=_build_run_output(include=_CONTRACT["expected_output_contains"]),
+                attesting_callsign="aiden",
+                attester_session_uuid=session_uuid,
+            )
+            cur.execute("SET LOCAL agency_os.callsign = 'dave'")
+            with pytest.raises(psycopg.errors.CheckViolation) as exc_info:
+                cur.execute(
+                    "UPDATE public.gate_roadmap SET status='proven', proof_run_id=%s WHERE id=%s",
+                    (run_id, gate_id),
+                )
+            assert "Check A" in str(exc_info.value), (
+                "Check A (exact cmd match) did not raise on superset cmd — "
+                "the verifier may have been weakened to substring/shape match. "
+                f"Got: {exc_info.value!s}"
+            )
+            assert "cmd_mismatch" in str(exc_info.value)
+    finally:
+        conn.rollback()
+        conn.close()


### PR DESCRIPTION
## Summary

Spike per `ceo:keiracom:proof_integration_plan_v1 → spike_mutation_gate` (ref `atlas-spike-mutation-gate`). Proves Check A of `fn_verify_before_proven` actually bites against three targeted mutants — including the directive's named "shape-only flip" mutant.

## Why a custom harness (not `mutmut` / `cosmic-ray`)

Neither tool is installed (`pip3 show mutmut/cosmic-ray` both `Package(s) not found`). More importantly, both mutate Python source — and the verifier we care about is a PL/pgSQL trigger inside Postgres. Mutating the Python test file would prove nothing about whether the trigger bites. The harness mutates the live `fn_verify_before_proven` body in place inside its own transaction, runs targeted negative-path probes, then ROLLS BACK so production sees zero DDL change.

## Safety model

- Harness runs in ONE long-lived `autocommit=False` transaction.
- Each mutant is applied via `CREATE OR REPLACE FUNCTION` inside that tx. Postgres DDL inside a tx is visible only to the executing tx until commit — concurrent connections continue to see the original fn the entire time.
- Harness never commits — `finally: conn.rollback()` discards all mutant DDL and every fixture row.
- Probe fixtures (`gate_roadmap`, `tool_call_log`, `gate_proof_runs`) are wrapped in `SAVEPOINT`s so an inner `check_violation` from the mutant doesn't break the outer tx state.

## Mutants exercised

| Mutant ID | Description |
|---|---|
| `M1_invert_distinct_from` | `IS DISTINCT FROM` → `IS NOT DISTINCT FROM` (logical inversion) |
| `M2_never_raise` | condition → `false` (Check A becomes a no-op) |
| `M3_substring_match` | exact match → `position(v_expected_cmd IN v_run_cmd) = 0` (today's shape-only flip — would accept a pytest-only attestation when `contract.cmd` is a substring of `run_cmd`) |

## Scenarios

| Scenario | `run_cmd` shape | What it isolates |
|---|---|---|
| `UNRELATED_CMD` | `WRONG_CMD_unrelated` | Catches M1 + M2 — Check A skipped, `trg_11` raises dual-attest instead, message lacks Check A tokens |
| `SUPERSET_CMD` | `contract.cmd + " --extra-arg suffix"` | Catches M3 — substring match passes, downstream `trg_11` catches it, message lacks Check A tokens |

A mutant is **KILLED** when the probe no longer observes both `"Check A"` and `"cmd_mismatch"` in the error message — either because the mutant raised something else or because it didn't raise at all.

## Verbatim mutation report

```
==============================================================================
MUTATION REPORT
==============================================================================
Mutant ID                         Status      Scenario outcomes
------------------------------------------------------------------------------
M1_invert_distinct_from           KILLED      UNRELATED_CMD=RAISED_OTHER, SUPERSET_CMD=RAISED_OTHER
M2_never_raise                    KILLED      UNRELATED_CMD=RAISED_OTHER, SUPERSET_CMD=RAISED_OTHER
M3_substring_match                KILLED      UNRELATED_CMD=RAISED_CHECK_A, SUPERSET_CMD=RAISED_OTHER

Total: 3 KILLED, 0 SURVIVED, 0 NO_APPLY (out of 3).
EXIT_CODE: 0
```

Per-mutant detail (verbatim from the harness):

```
--- MUTANT M3_substring_match ---
    Weaken exact match to substring match — today's shape-only flip
    scenario=UNRELATED_CMD   outcome=RAISED_CHECK_A
      message: proof_gate_contract Check A (cmd_mismatch): gate_proof_runs.run_cmd=WRONG_CMD_unrelated does not equal contract.cmd=EXACTCMD_FOR_SPIKE for gate_roadmap_id=335cf582-…
    scenario=SUPERSET_CMD    outcome=RAISED_OTHER
      message: gate dual-attest: max binding_reviewer proof run required before proven for gate_roadmap_id=a97b8847-…
CONTEXT:  PL/pgSQL function fn_gate_proven_dual_attest() line 21 at RAISE
```

The directive's named mutant is **KILLED by the SUPERSET_CMD scenario**: under M3 (substring match), `position('EXACTCMD_FOR_SPIKE' IN 'EXACTCMD_FOR_SPIKE --extra-arg suffix') > 0`, so Check A no longer raises; the downstream `trg_11 fn_gate_proven_dual_attest` catches it instead, with a message that lacks both `"Check A"` and `"cmd_mismatch"` tokens.

## Permanent regression catch

`tests/db/test_proof_gate_ledger_spike_mutation.py::test_negative_cmd_superset_raises` encodes the same assertion the harness uses, so the dogfood pytest suite picks up future regressions of Check A even without the harness running.

Lives in its OWN file (not the dogfood file) — the four contract-locked function names in `tests/db/test_proof_gate_ledger.py` stay byte-equal to the `proof_gate_contract.expected_output_contains` list on the dogfood `gate_roadmap` row.

Combined dogfood + spike pytest run:

```
$ TEST_DATABASE_URL=... PYTHONPATH=/home/elliotbot/clawd/Agency_OS \
    python3 -m pytest tests/db/test_proof_gate_ledger_spike_mutation.py tests/db/test_proof_gate_ledger.py -v
tests/db/test_proof_gate_ledger_spike_mutation.py::test_negative_cmd_superset_raises PASSED [ 20%]
tests/db/test_proof_gate_ledger.py::test_negative_mismatched_output_raises PASSED [ 40%]
tests/db/test_proof_gate_ledger.py::test_negative_cmd_mismatch_raises PASSED [ 60%]
tests/db/test_proof_gate_ledger.py::test_negative_attester_ne_builder_raises PASSED [ 80%]
tests/db/test_proof_gate_ledger.py::test_positive_control_accepted PASSED [100%]
============================== 5 passed in 7.87s ===============================
```

## Survivors / findings

**None** — all three applied mutants were KILLED. Worth flagging that the existing `test_negative_cmd_mismatch_raises` in the dogfood file uses an `UNRELATED_CMD`-shape `run_cmd` (`"WRONG_CMD"`), which the harness shows would **survive M3 in isolation** — Check A still raises under M3 for that scenario because `'EXACTCMD_FOR_DOGFOOD'` is not a substring of `'WRONG_CMD'`. The new `test_negative_cmd_superset_raises` covers that gap.

## Lint

`ruff format --check` + `ruff check` both green on both files.

## No production state changed

Harness rolled back; `gate_roadmap` and `gate_proof_runs` state untouched. The new pytest test wraps each probe in `conn.rollback()` per dogfood pattern.

## Sequence per directive

`SEQUENCE: spike_mutation_gate first. Re-prove after.` — this PR is the spike. The re-prove of `product_proof_enforcement` (id `8ccca6bc-…`) follows.

🤖 Atlas — Tier A build clone (engineering execution)