### PR TITLE
[NOVA] feat(context_watchdog): activity-signal wire-up + flap guard (closes false-green hole)

### DIFF
--- a/scripts/orchestrator/context_watchdog.py
+++ b/scripts/orchestrator/context_watchdog.py
@@ -86,6 +86,15 @@ def is_context_full(pane: str) -> bool:
 # is_genuinely_stuck (the loose-substring check is unreliable as a
 # permission signal in isolation).
 
+# Flap-guard (agent_activity wire-up — nova-agent-activity-watchdog-wire).
+# If the same agent is classified as needing wake N times within a rolling
+# window, STOP auto-waking and post #ceo so a human triages the blocker.
+# Per-agent state lives in /tmp/watchdog-flap-<callsign>.json so a stuck
+# single agent does not contaminate the shared watchdog state file.
+FLAP_WINDOW_SEC = 30 * 60  # 30-minute rolling window
+FLAP_THRESHOLD = 3  # 3 wakes in window → flap
+FLAP_STATE_PATH_TEMPLATE = "/tmp/watchdog-flap-{name}.json"
+
 PERMISSION_PROMPT_TOKENS = ("⏵⏵", "bypass permiss")
 GENUINE_STALL_INDICATORS = (
     "Error:",
@@ -661,6 +670,67 @@ def revive_agent(name: str, target: str, reason: str, last_task: str = "") -> No
     slack_ceo(f"[ELLIOT] Watchdog revived {name} ({reason}).")
 
 
+def _flap_state_path(name: str) -> Path:
+    return Path(FLAP_STATE_PATH_TEMPLATE.format(name=name))
+
+
+def load_flap_events(name: str, now: float) -> list[float]:
+    """Return wake-event timestamps for `name` within FLAP_WINDOW_SEC of `now`.
+
+    Drops events outside the window and silently swallows read errors — the
+    flap signal is advisory, not load-bearing.
+    """
+    path = _flap_state_path(name)
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+        events = data.get("events", [])
+    except Exception:
+        return []
+    return [t for t in events if isinstance(t, (int, float)) and (now - t) < FLAP_WINDOW_SEC]
+
+
+def record_flap_event(name: str, now: float) -> None:
+    """Append a wake event for `name` at `now`; prune the file to the active window."""
+    events = load_flap_events(name, now)
+    events.append(now)
+    try:
+        _flap_state_path(name).write_text(json.dumps({"events": events}))
+    except Exception:
+        pass
+
+
+def is_flap_tripped(name: str, now: float) -> bool:
+    """True iff `name` has been woken FLAP_THRESHOLD+ times within the window.
+
+    Threshold check uses >= so the third wake inside the window arms the guard
+    — the fourth wake is the one that's suppressed. This matches the dispatch's
+    'woken 3x' phrasing (the 3rd wake is the alarm trigger; further wakes are
+    blocked until events age out of the window).
+    """
+    return len(load_flap_events(name, now)) >= FLAP_THRESHOLD
+
+
+def _try_classify_activity(name: str) -> str:
+    """Best-effort wrapper around scripts.orchestrator.agent_activity.
+
+    Returns 'no_data' on any error (import miss, DB unreachable, callsign
+    absent). The fail-open contract lets the watchdog fall through to its
+    existing pane-based detection (is_genuinely_stuck) when the activity
+    signal is uninformative.
+    """
+    try:
+        from scripts.orchestrator.agent_activity import (  # noqa: PLC0415
+            compute_activity_state,
+        )
+
+        return compute_activity_state(name)
+    except Exception as exc:  # noqa: BLE001 — fail-open: never block watchdog cycle
+        print(f"[watchdog] activity-state lookup failed for {name}: {exc}")
+        return "no_data"
+
+
 def check_other_agents(state: dict) -> dict:
     """Check non-Elliot agents for context-full or stuck.
 
@@ -716,7 +786,8 @@ def check_other_agents(state: dict) -> dict:
         if is_context_full(pane):
             revive_agent(name, target, "context-full", last_task=last_task)
             state[key_revive] = now
-        elif is_genuinely_stuck(pane):
+            continue
+        if is_genuinely_stuck(pane):
             # Ground-truth gate: if the fleet is shipping work in the recent
             # window, individual pane idleness is not a stall — skip revive.
             if check_ground_truth_progress(IDLE_TIMEOUT_MIN * 60):
@@ -724,6 +795,56 @@ def check_other_agents(state: dict) -> dict:
                 continue
             revive_agent(name, target, "error-detected", last_task=last_task)
             state[key_revive] = now
+            continue
+
+        # Activity-state wire-up (nova-agent-activity-watchdog-wire). The
+        # pane-hash-stable false-green that masked Scout + Nova idle for 48-51min
+        # is closed here: tool_call_log activity (per Scout's compute_activity_
+        # state) is the finer signal that the pane cannot reveal — an agent
+        # sitting at a quiet ❯ with 0 tool calls in 10 min is silent regardless
+        # of whether the pane bytes changed.
+        #
+        # Five-class dispatch:
+        #   active                -> skip (calls in the last 10 min)
+        #   idle_with_work_queued -> revive (inbox has dispatch waiting; the
+        #                             inbox-watcher delivers on wake)
+        #   idle                  -> leave (NO THRASH — no inbox = no fresh work)
+        #   no_data               -> skip (DB / helper unavailable; the
+        #                             pane-based context-full + genuine-stuck
+        #                             branches above already covered the
+        #                             pane-visible failure modes)
+        #
+        # Flap guard: 3 wakes in FLAP_WINDOW_SEC for the same agent suspends
+        # further auto-wakes and posts #ceo — protects against thrash when a
+        # wake fails to land work (agent stalls again immediately).
+        activity_state = _try_classify_activity(name)
+        if activity_state == "idle_with_work_queued":
+            if is_flap_tripped(name, now):
+                flap_key = f"{name}_flap_alerted_at"
+                last_alert = state.get(flap_key, 0)
+                if now - last_alert >= ESCALATION_COOLDOWN_SEC:
+                    slack_ceo(
+                        f"[ELLIOT] FLAP: {name} woken {FLAP_THRESHOLD}x in "
+                        f"{FLAP_WINDOW_SEC // 60}min — possible blocker. "
+                        "Auto-wake suspended until events age out of window."
+                    )
+                    state[flap_key] = now
+                print(f"[watchdog] {name} FLAP guard tripped — wake suspended")
+                continue
+            revive_agent(name, target, "idle_with_work_queued", last_task=last_task)
+            state[key_revive] = now
+            record_flap_event(name, now)
+            print(f"[watchdog] {name} idle_with_work_queued — wake injected")
+        elif activity_state == "active":
+            # Tool calls within the last 10 min — agent is doing work.
+            pass
+        elif activity_state == "idle":
+            # No work queued — NO THRASH. Leaving the agent untouched is the
+            # whole point of the inbox check: an agent that finished its work
+            # cleanly and is awaiting dispatch must not be repeatedly woken.
+            print(f"[watchdog] {name} idle (no inbox) — leave (no-thrash)")
+        # activity_state == "no_data" falls through silently (pane-based
+        # branches above are the safety net).
     return state
 
 
@@ -763,16 +884,40 @@ def main() -> None:
             )
             state["elliot_wake_sent"] = 0  # reset to avoid spam loop
     elif not wake_sent:
-        # No active wake; check for idle-too-long (Problem B standalone)
-        idle_secs = now - state.get("elliot_last_hash_ts", now)
-        if idle_secs > IDLE_TIMEOUT_MIN * 60:
-            # Ground-truth gate: fleet shipping work means Elliot isn't the
-            # blocker — skip the wake. Prevents nuisance pings during deep
-            # multi-agent work where Elliot's pane is correctly quiet.
-            if check_ground_truth_progress(IDLE_TIMEOUT_MIN * 60):
-                print("[watchdog] elliot idle but ground-truth shows progress — skip wake")
+        # No active wake. Check tool_call_log first — the 10-min activity-
+        # signal supersedes the 40-min pane-hash idle check (the pane-hash was
+        # the false-green source that masked Scout/Nova for 48-51min; pane
+        # bytes can stay stable at a quiet ❯ while the agent makes zero tool
+        # calls). Pane-hash kept ONLY as the no_data fallback below.
+        activity_state = _try_classify_activity("elliot")
+        if activity_state == "idle_with_work_queued":
+            if is_flap_tripped("elliot", now):
+                last_alert = state.get("elliot_flap_alerted_at", 0)
+                if now - last_alert >= ESCALATION_COOLDOWN_SEC:
+                    slack_ceo(
+                        f"[ELLIOT] FLAP: elliot woken {FLAP_THRESHOLD}x in "
+                        f"{FLAP_WINDOW_SEC // 60}min — possible blocker. "
+                        "Auto-wake suspended until events age out of window."
+                    )
+                    state["elliot_flap_alerted_at"] = now
+                print("[watchdog] elliot FLAP guard tripped — wake suspended")
             else:
                 state = wake_idle_elliot(state, now)
+                record_flap_event("elliot", now)
+                print("[watchdog] elliot idle_with_work_queued — wake injected")
+        elif activity_state == "idle":
+            # No inbox work → leave (NO THRASH).
+            print("[watchdog] elliot idle (no inbox) — leave (no-thrash)")
+        elif activity_state == "active":
+            # Tool calls within 10 min — Elliot is driving the fleet.
+            pass
+        else:  # no_data — fall back to the legacy pane-hash idle check.
+            idle_secs = now - state.get("elliot_last_hash_ts", now)
+            if idle_secs > IDLE_TIMEOUT_MIN * 60:
+                if check_ground_truth_progress(IDLE_TIMEOUT_MIN * 60):
+                    print("[watchdog] elliot idle but ground-truth shows progress — skip wake")
+                else:
+                    state = wake_idle_elliot(state, now)
 
     # ── Other agents ─────────────────────────────────────────────────────
     state = check_other_agents(state)

--- a/tests/orchestrator/test_context_watchdog_activity_wire.py
+++ b/tests/orchestrator/test_context_watchdog_activity_wire.py
@@ -1,0 +1,262 @@
+"""Tests for the agent_activity wire-up in context_watchdog
+(nova-agent-activity-watchdog-wire).
+
+Covers:
+  - Flap-guard window math (load / record / threshold)
+  - check_other_agents per-state dispatch (active / idle_with_work_queued /
+    idle / no_data) including flap suppression
+  - Negative path: idle + no inbox → NO wake (no-thrash invariant)
+  - Negative path: flap-tripped agent → NO wake + #ceo slack post
+
+Pattern mirrors test_context_watchdog.py: monkeypatch side-effecting seams
+(pane_capture, send_pane, slack_ceo, revive_agent, compute_activity_state) so
+no real tmux / DB / Slack is reached.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture
+def cw(tmp_path, monkeypatch):
+    """Fresh context_watchdog import with flap-state files routed into tmp_path.
+
+    Per-test isolation: each test gets its own tmp dir for flap state files so
+    the global /tmp/watchdog-flap-*.json files (production state) are not
+    touched. Also prevents flap events bleeding between tests via the file
+    system."""
+    mod = importlib.import_module("scripts.orchestrator.context_watchdog")
+    mod = importlib.reload(mod)
+    # Reroute flap state files into tmp_path.
+    template = str(tmp_path / "watchdog-flap-{name}.json")
+    monkeypatch.setattr(mod, "FLAP_STATE_PATH_TEMPLATE", template)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Flap-guard primitives
+# ---------------------------------------------------------------------------
+
+
+def test_flap_load_empty_when_no_file(cw):
+    assert cw.load_flap_events("ghost", now=1000.0) == []
+
+
+def test_flap_record_appends_event(cw):
+    cw.record_flap_event("nova", now=1000.0)
+    cw.record_flap_event("nova", now=1100.0)
+    events = cw.load_flap_events("nova", now=1200.0)
+    assert events == [1000.0, 1100.0]
+
+
+def test_flap_load_drops_events_outside_window(cw):
+    # Three events: two inside the window (relative to now=10_000), one outside.
+    cw.record_flap_event("nova", now=1000.0)  # inside
+    cw.record_flap_event("nova", now=2000.0)  # inside
+    cw.record_flap_event("nova", now=5000.0)  # outside (5000 + 1800 < 10000)
+    now = 10_000.0  # FLAP_WINDOW_SEC default = 1800
+    events = cw.load_flap_events("nova", now=now)
+    # All events older than 10000 - 1800 = 8200 are dropped → all three drop.
+    assert events == []
+    # Recent events stay.
+    cw.record_flap_event("nova", now=9500.0)
+    assert cw.load_flap_events("nova", now=now) == [9500.0]
+
+
+def test_flap_tripped_at_threshold(cw):
+    """Threshold is inclusive (>=): 3 wakes in the window arms the guard;
+    the 4th wake attempt is the one suppressed by is_flap_tripped."""
+    now = 1000.0
+    assert not cw.is_flap_tripped("nova", now)
+    cw.record_flap_event("nova", now)
+    assert not cw.is_flap_tripped("nova", now)
+    cw.record_flap_event("nova", now)
+    assert not cw.is_flap_tripped("nova", now)
+    cw.record_flap_event("nova", now)
+    # Third event in the window → tripped.
+    assert cw.is_flap_tripped("nova", now)
+
+
+def test_flap_state_file_corruption_falls_back_to_empty(cw, tmp_path):
+    bad = tmp_path / "watchdog-flap-nova.json"
+    bad.write_text("{not json")
+    assert cw.load_flap_events("nova", now=1000.0) == []
+
+
+# ---------------------------------------------------------------------------
+# check_other_agents wire-up — per-state dispatch
+# ---------------------------------------------------------------------------
+
+
+def _install_seams(cw, monkeypatch, *, activity_state: str, pane: str = "idle ❯") -> dict:
+    """Stub the pane + activity-state seams. Returns a dict where the test
+    can observe whether revive_agent was called and the args it received."""
+    calls: dict = {"revives": [], "slack": []}
+
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: pane)
+    monkeypatch.setattr(cw, "_try_classify_activity", lambda _name: activity_state)
+    monkeypatch.setattr(cw, "is_context_full", lambda _p: False)
+    monkeypatch.setattr(cw, "is_genuinely_stuck", lambda _p: False)
+    monkeypatch.setattr(cw, "is_permission_prompt", lambda _p: False)
+
+    def _record_revive(name, target, reason, last_task=""):  # noqa: ANN001
+        calls["revives"].append({"name": name, "reason": reason, "last_task": last_task})
+
+    monkeypatch.setattr(cw, "revive_agent", _record_revive)
+    monkeypatch.setattr(cw, "slack_ceo", lambda msg: calls["slack"].append(msg))
+    # Restrict the agent set so one assertion = one agent.
+    monkeypatch.setattr(cw, "AGENTS", {"nova": "nova:0.0"})
+    return calls
+
+
+def test_idle_with_work_queued_triggers_revive(cw, monkeypatch):
+    calls = _install_seams(cw, monkeypatch, activity_state="idle_with_work_queued")
+    cw.check_other_agents({})
+    assert len(calls["revives"]) == 1
+    assert calls["revives"][0]["name"] == "nova"
+    assert calls["revives"][0]["reason"] == "idle_with_work_queued"
+
+
+def test_idle_no_inbox_does_NOT_revive(cw, monkeypatch):
+    """No-thrash invariant: pure idle (no inbox) MUST be left untouched. This
+    is the negative path the dispatch's proof gate requires."""
+    calls = _install_seams(cw, monkeypatch, activity_state="idle")
+    cw.check_other_agents({})
+    assert calls["revives"] == []
+
+
+def test_active_does_NOT_revive(cw, monkeypatch):
+    calls = _install_seams(cw, monkeypatch, activity_state="active")
+    cw.check_other_agents({})
+    assert calls["revives"] == []
+
+
+def test_no_data_does_NOT_revive(cw, monkeypatch):
+    """no_data is the pane-based safety-net fall-through. With genuine_stuck=
+    False and context_full=False (set by _install_seams), no_data → no action
+    here. The existing pane branches (tested in test_context_watchdog.py) own
+    the no_data failure modes."""
+    calls = _install_seams(cw, monkeypatch, activity_state="no_data")
+    cw.check_other_agents({})
+    assert calls["revives"] == []
+
+
+def test_flap_tripped_suppresses_revive_and_posts_slack(cw, monkeypatch):
+    """3 prior wake events in the window → next idle_with_work_queued call
+    must NOT revive AND must post a single #ceo flap alert."""
+    # Seed three flap events at a known time within the window.
+    now = 5000.0
+    monkeypatch.setattr("time.time", lambda: now)
+    cw.record_flap_event("nova", now - 100)
+    cw.record_flap_event("nova", now - 200)
+    cw.record_flap_event("nova", now - 300)
+    assert cw.is_flap_tripped("nova", now)
+
+    calls = _install_seams(cw, monkeypatch, activity_state="idle_with_work_queued")
+    state = cw.check_other_agents({})
+
+    assert calls["revives"] == []
+    assert len(calls["slack"]) == 1
+    assert "FLAP" in calls["slack"][0]
+    assert "nova" in calls["slack"][0]
+    # Cooldown timestamp recorded for slack-spam suppression.
+    assert state.get("nova_flap_alerted_at") == now
+
+
+def test_flap_slack_alert_obeys_escalation_cooldown(cw, monkeypatch):
+    """Two flap-tripped cycles inside ESCALATION_COOLDOWN_SEC → only one
+    slack_ceo post (the second cycle silently suppresses)."""
+    now = 5000.0
+    monkeypatch.setattr("time.time", lambda: now)
+    cw.record_flap_event("nova", now - 100)
+    cw.record_flap_event("nova", now - 200)
+    cw.record_flap_event("nova", now - 300)
+
+    calls = _install_seams(cw, monkeypatch, activity_state="idle_with_work_queued")
+    # First cycle — slack posted, cooldown stamped.
+    state = cw.check_other_agents({})
+    assert len(calls["slack"]) == 1
+    # Second cycle immediately after — slack NOT posted (cooldown active).
+    cw.check_other_agents(state)
+    assert len(calls["slack"]) == 1  # unchanged
+
+
+def test_revive_records_flap_event(cw, monkeypatch):
+    """A successful idle_with_work_queued revive must record a flap event so
+    the threshold can be reached on subsequent cycles."""
+    now = 5000.0
+    monkeypatch.setattr("time.time", lambda: now)
+    calls = _install_seams(cw, monkeypatch, activity_state="idle_with_work_queued")
+    cw.check_other_agents({})
+    assert len(calls["revives"]) == 1
+    events = cw.load_flap_events("nova", now)
+    assert len(events) == 1
+    assert events[0] == pytest.approx(now)
+
+
+# ---------------------------------------------------------------------------
+# Existing pane-based branches still win over activity-state
+# ---------------------------------------------------------------------------
+
+
+def test_context_full_still_takes_precedence(cw, monkeypatch):
+    """is_context_full=True must trigger revive(context-full) regardless of
+    activity_state — the structural pane signal is authoritative for the
+    'dead agent needs /clear' case (per check_other_agents header comment)."""
+    calls = {"revives": []}
+    monkeypatch.setattr(cw, "pane_capture", lambda _t: "100% context used")
+    monkeypatch.setattr(cw, "is_context_full", lambda _p: True)
+    monkeypatch.setattr(cw, "is_permission_prompt", lambda _p: False)
+    monkeypatch.setattr(cw, "is_genuinely_stuck", lambda _p: False)
+    monkeypatch.setattr(
+        cw,
+        "_try_classify_activity",
+        lambda _n: "active",  # would normally skip
+    )
+    monkeypatch.setattr(
+        cw,
+        "revive_agent",
+        lambda name, target, reason, last_task="": calls["revives"].append(
+            {"name": name, "reason": reason}
+        ),
+    )
+    monkeypatch.setattr(cw, "AGENTS", {"nova": "nova:0.0"})
+
+    cw.check_other_agents({})
+    assert len(calls["revives"]) == 1
+    assert calls["revives"][0]["reason"] == "context-full"
+
+
+# ---------------------------------------------------------------------------
+# _try_classify_activity fail-open
+# ---------------------------------------------------------------------------
+
+
+def test_try_classify_returns_no_data_on_import_error(cw, monkeypatch):
+    """If the helper module / function cannot be reached, the wrapper must
+    return 'no_data' so the watchdog falls through to its pane-based safety
+    net rather than crashing the cycle."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blow_up_on_agent_activity(name, *args, **kwargs):
+        if name == "scripts.orchestrator.agent_activity":
+            raise ImportError("simulated missing helper")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blow_up_on_agent_activity)
+    assert cw._try_classify_activity("nova") == "no_data"
+
+
+def test_try_classify_returns_no_data_on_helper_exception(cw, monkeypatch):
+    import scripts.orchestrator.agent_activity as aa
+
+    def _boom(_callsign):
+        raise RuntimeError("DB exploded")
+
+    monkeypatch.setattr(aa, "compute_activity_state", _boom)
+    assert cw._try_classify_activity("nova") == "no_data"


### PR DESCRIPTION
## STEP 0 verbatim (per Elliot's amended dispatch)
> The current watchdog IS a standalone systemd service (elliot-context-watchdog.timer, 10-min cadence, NOT coupled to Elliot's session). But it detects idleness via pane-hash change (IDLE_TIMEOUT_MIN=40min), NOT via tool_call_log. Nova and Scout were stuck because their panes were at a stable prompt that looked unchanged — pane hash stable, not context-full — so the watchdog saw 'alive at prompt' not 'stalled.' The tool_call_log had 0 rows for 48-51 min, which the watchdog never checked. That is the gap.

Verified at HEAD of \`scripts/orchestrator/context_watchdog.py\`:
- \`is_context_full(pane)\` ⇒ \`\"100% context used\" in pane or \"Usage credits required\" in pane\` (revives via \`revive_agent(reason=\"context-full\")\`)
- \`is_genuinely_stuck(pane)\` ⇒ pane contains \`Error: / Traceback / Allow+Deny\` (revives via \`revive_agent(reason=\"error-detected\")\`, gated by \`check_ground_truth_progress\`)
- Elliot main path ⇒ idle wake when \`now - elliot_last_hash_ts > IDLE_TIMEOUT_MIN*60\` (40 min) ← **the false-green source**
- No path checked \`tool_call_log\` ⇒ a quiet pane at \`❯\` with 0 calls/10m was invisible

## Summary
- Per-agent dispatch added INSIDE the existing \`check_other_agents\` sweep (no new daemon, no new loop): \`active\` → skip, \`idle_with_work_queued\` → \`revive_agent\` + record flap event, \`idle\` → leave (NO THRASH), \`no_data\` → fall through to pane-based safety net.
- Flap guard: per-agent \`/tmp/watchdog-flap-<callsign>.json\` rolling 30-min window; 3 wakes ⇒ \`is_flap_tripped\` returns True; next \`idle_with_work_queued\` attempt does **not** wake; posts \`#ceo FLAP: <callsign> woken 3x — possible blocker\` (rate-limited by \`ESCALATION_COOLDOWN_SEC\` so a tripped guard does not slack-spam every 10-min cycle).
- Elliot's path: the 40-min pane-hash idle check is replaced with the 10-min activity-state check. Pane-hash kept as \`no_data\` fallback so a DB outage degrades to pre-build behaviour rather than disabling Elliot's idle wake entirely.
- Pane-based branches (\`is_context_full\`, \`is_permission_prompt\`, \`is_genuinely_stuck\`) keep precedence — structural pane signals are authoritative for the 'needs /clear' case regardless of tool_call cadence (test \`test_context_full_still_takes_precedence\`).

## Base
This PR is branched off \`scout/agent-activity-signal\` (Scout's PR #1426 — \`agent_activity.py\` helper + \`agent_activity_signal\` view + \`fleet_liveness_status\` JOIN). Rebase to \`main\` once #1426 lands.

## Proof gate plan (negative tests included)
Run by an attester (attester ≠ builder) post-merge:
1. **Positive**: stop tool calls on the test agent for 10 min, place a file in \`/tmp/telegram-relay-<agent>/inbox/\`, wait for the next watchdog tick. Expect the agent to receive a wake injection and emit a tool call within N min. Paste \`tool_call_log\` row + timestamp.
2. **Negative 1 (no-thrash)**: stop tool calls on a different test agent for 10 min with an EMPTY inbox dir. Watchdog runs ≥3 ticks. Expect zero wakes. Paste \`/tmp/watchdog-flap-<agent>.json\` (should not exist) and the \`[watchdog] <agent> idle (no inbox) — leave (no-thrash)\` print line from journal.
3. **Negative 2 (flap)**: force 3 wakes on the test agent within 30 min. Expect the 4th tick to log \`[watchdog] <agent> FLAP guard tripped — wake suspended\` and post a \`#ceo FLAP: <agent> woken 3x\` slack line. Paste both verbatim.

Unit-test coverage of all three paths is in \`tests/orchestrator/test_context_watchdog_activity_wire.py\` (15 tests, all green).

## Test plan
- [x] 15 new tests in \`tests/orchestrator/test_context_watchdog_activity_wire.py\` (flap primitives × 5, per-state dispatch × 4, flap suppression + cooldown × 2, revive records flap event × 1, context-full precedence × 1, fail-open × 2)
- [x] Full regression: \`python3 -m pytest tests/orchestrator/test_context_watchdog.py tests/orchestrator/test_context_watchdog_resume.py tests/orchestrator/test_agent_activity.py tests/orchestrator/test_context_watchdog_activity_wire.py -q\` ⇒ **110 passed in 7.86s** (15 new + 95 prior)
- [x] \`ruff check\` + \`ruff format\` clean on touched files (5 pre-existing SIM105 in untouched functions noted; out of CI scope — CI lints \`src/\` only, this lives in \`scripts/\`)

## Reviewers
Aiden + Max (author-exclusion — 2/2 NATS concur required).

ref: nova-agent-activity-watchdog-wire

🤖 Generated with [Claude Code](https://claude.com/claude-code)