### PR TITLE
[ATLAS] cleanup(fleet_supervisor): drop dead SonarCloud fetch + format helpers (Agency_OS-6b2s)

### DIFF
--- a/scripts/fleet_supervisor.py
+++ b/scripts/fleet_supervisor.py
@@ -1022,79 +1022,24 @@ def build_task_prompt(task_id: str, title: str, description: str) -> str:
     )
 
 
-_SONAR_PROJECT_KEY = "Keiracom_Agency_OS"
-_SONAR_BASE = "https://sonarcloud.io/api"
-
-
-def fetch_sonar_status(pr_number: int) -> dict[str, Any]:
-    """KEI-189: dual-endpoint Sonar verify — issues + Quality Gate.
-
-    /api/issues/search returns S-rule findings (bugs/code smells/vulnerabilities).
-    /api/qualitygates/project_status returns the QG verdict including SEPARATE
-    conditions like new_duplicated_lines_density that the issues endpoint
-    does NOT surface.
-
-    Anchored on PRs #940/#963/#981 today where issues=0 but QG=ERROR on
-    dup-density — three of us missed the gap because we only checked /issues.
-    Encodes the feedback_sonarcloud_verify_pattern memory pin mechanically.
-
-    Returns {"issues_total": int, "qg_status": str, "qg_failing": list[str]}
-    on success; {} on any fetch failure (fail-open — review still proceeds,
-    agent sees missing-data in brief and can run curl themselves).
-    """
-    out: dict[str, Any] = {}
-    issues_url = f"{_SONAR_BASE}/issues/search?componentKeys={_SONAR_PROJECT_KEY}&pullRequest={pr_number}&resolved=false"
-    qg_url = f"{_SONAR_BASE}/qualitygates/project_status?projectKey={_SONAR_PROJECT_KEY}&pullRequest={pr_number}"
-    try:
-        with urllib.request.urlopen(issues_url, timeout=10) as resp:
-            data = json.loads(resp.read())
-        out["issues_total"] = int(data.get("total", 0))
-    except Exception as exc:
-        log.warning("Sonar /issues fetch failed for PR #%d: %s", pr_number, exc)
-    try:
-        with urllib.request.urlopen(qg_url, timeout=10) as resp:
-            data = json.loads(resp.read())
-        ps = data.get("projectStatus", {})
-        out["qg_status"] = ps.get("status", "UNKNOWN")
-        out["qg_failing"] = [
-            f"{c.get('metricKey')}={c.get('actualValue')} (>{c.get('errorThreshold')})"
-            for c in ps.get("conditions", [])
-            if c.get("status") == "ERROR"
-        ]
-    except Exception as exc:
-        log.warning("Sonar /qualitygates fetch failed for PR #%d: %s", pr_number, exc)
-    return out
-
-
-def _format_sonar_brief(sonar: dict[str, Any]) -> str:
-    """Format Sonar status for inclusion in the review brief. Returns empty
-    string if no data fetched (fail-open — reviewer runs curl themselves)."""
-    if not sonar:
-        return ""
-    lines = ["", "Sonar (BOTH endpoints — issues + QG — checked at brief-emit time):"]
-    if "issues_total" in sonar:
-        lines.append(f"  • /api/issues/search → total NEW unresolved: {sonar['issues_total']}")
-    if "qg_status" in sonar:
-        lines.append(f"  • /api/qualitygates/project_status → status: {sonar['qg_status']}")
-        for cond in sonar.get("qg_failing", []) or []:
-            lines.append(f"      FAIL: {cond}")
-    lines.append(
-        "  ⚠ APPROVE requires BOTH endpoints clean (issues=0 AND QG=OK). "
-        "QG can ERROR on dimensions like new_duplicated_lines_density that issues misses."
-    )
-    return "\n".join(lines)
-
-
 def build_review_prompt(pr_number: int, pr_title: str, pr_url: str, callsign: str) -> str:
-    """Emit the review-claim prompt. KEI-189: includes Sonar issues + QG snapshot."""
-    sonar = fetch_sonar_status(pr_number)
-    sonar_block = _format_sonar_brief(sonar)
+    """Emit the review-claim prompt.
+
+    Agency_OS-6b2s (2026-06-03): the legacy KEI-189 dual-endpoint Sonar
+    snapshot (fetch_sonar_status + _format_sonar_brief) was dropped from
+    this prompt. SonarCloud's CI workflow was removed in PR #1138; spot
+    checks across PRs #1414–#1431 confirm no SonarCloud check fires on
+    Agency_OS PRs anymore (CodeQL is the sole code-analysis gate). The
+    fetch was therefore live code calling a dead API — every review
+    prompt burned two HTTP timeouts logging warnings to no benefit.
+    Reviewer instructions now point at CI alone.
+    """
     return (
         f"You auto-claimed review of PR #{pr_number}: {pr_title}. "
         f"URL: {pr_url}. "
-        f"Run `gh pr view {pr_number}` + check CI/Sonar, "
+        f"Run `gh pr view {pr_number}` + check CI, "
         f"post [REVIEW:{callsign}] APPROVE or HOLD with verbatim evidence. "
-        f"Don't ask — execute.{sonar_block}"
+        "Don't ask — execute."
     )
 
 

--- a/tests/scripts/test_fleet_supervisor.py
+++ b/tests/scripts/test_fleet_supervisor.py
@@ -888,96 +888,37 @@ def test_agent_has_reviewed_skips_pr_with_hold_comment(monkeypatch):
     assert fs.agent_has_reviewed(pr, "scout") is True
 
 
-# ─── KEI-189: Sonar QG dual-endpoint check ───────────────────────────────────
+# Agency_OS-6b2s (2026-06-03): the legacy KEI-189 Sonar QG dual-endpoint
+# tests have been removed alongside fetch_sonar_status / _format_sonar_brief
+# in fleet_supervisor.py. SonarCloud's CI workflow was deleted in PR #1138;
+# CodeQL is the sole code-analysis gate on Agency_OS PRs. The new
+# test_build_review_prompt_no_longer_calls_sonar regression check below
+# pins that the prompt does not mention Sonar (catches accidental
+# re-introduction of the dead code path).
 
 
-def test_fetch_sonar_status_returns_both_dimensions(monkeypatch):
-    """KEI-189: fetch_sonar_status reads issues + QG endpoints."""
-
-    class _Resp:
-        def __init__(self, body):
-            self._body = body
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, *_):
-            return None
-
-        def read(self):
-            return self._body
-
-    def fake_urlopen(req, timeout=10):
-        url = req if isinstance(req, str) else getattr(req, "full_url", "")
-        if "issues/search" in url:
-            return _Resp(b'{"total": 3, "issues": []}')
-        if "qualitygates/project_status" in url:
-            return _Resp(
-                b'{"projectStatus": {"status": "ERROR", "conditions": ['
-                b'{"metricKey": "new_duplicated_lines_density", "status": "ERROR",'
-                b'"actualValue": "19.3", "errorThreshold": "3"}]}}'
-            )
-        return _Resp(b"{}")
-
-    monkeypatch.setattr(fs.urllib.request, "urlopen", fake_urlopen)
-    out = fs.fetch_sonar_status(981)
-    assert out["issues_total"] == 3
-    assert out["qg_status"] == "ERROR"
-    assert any("new_duplicated_lines_density" in c for c in out["qg_failing"])
-
-
-def test_fetch_sonar_status_fail_open(monkeypatch):
-    """Sonar fetch failure → empty dict, never raises."""
-
-    def bad_urlopen(*_a, **_k):
-        raise RuntimeError("network down")
-
-    monkeypatch.setattr(fs.urllib.request, "urlopen", bad_urlopen)
-    out = fs.fetch_sonar_status(999)
-    # Empty dict — fail-open, no fields set, no exception
-    assert out == {}
-
-
-def test_format_sonar_brief_renders_both_endpoints():
-    sonar = {
-        "issues_total": 2,
-        "qg_status": "ERROR",
-        "qg_failing": ["new_duplicated_lines_density=19.3 (>3)"],
-    }
-    text = fs._format_sonar_brief(sonar)
-    assert "/api/issues/search" in text
-    assert "total NEW unresolved: 2" in text
-    assert "/api/qualitygates/project_status" in text
-    assert "status: ERROR" in text
-    assert "new_duplicated_lines_density" in text
-    assert "BOTH endpoints" in text
-
-
-def test_format_sonar_brief_empty_when_no_data():
-    assert fs._format_sonar_brief({}) == ""
-
-
-def test_build_review_prompt_includes_sonar_block(monkeypatch):
-    """KEI-189 acceptance: review brief includes BOTH Sonar dimensions."""
-    monkeypatch.setattr(
-        fs,
-        "fetch_sonar_status",
-        lambda _n: {
-            "issues_total": 0,
-            "qg_status": "ERROR",
-            "qg_failing": ["new_duplicated_lines_density=19.3 (>3)"],
-        },
-    )
+def test_build_review_prompt_no_longer_calls_sonar():
+    """Agency_OS-6b2s: build_review_prompt must not reference SonarCloud."""
     prompt = fs.build_review_prompt(
         pr_number=981,
         pr_title="[ORION] feat(kei152): paddle",
         pr_url="https://github.com/x/y/pull/981",
         callsign="aiden",
     )
-    assert "Sonar" in prompt
-    assert "issues_total" in prompt or "total NEW" in prompt
-    assert "qg_status" in prompt or "status: ERROR" in prompt
-    assert "BOTH endpoints" in prompt
+    lowered = prompt.lower()
+    assert "sonar" not in lowered, (
+        "build_review_prompt mentions Sonar — the dead-API fetch was supposed "
+        "to be dropped in Agency_OS-6b2s (CodeQL is the sole code-analysis "
+        f"gate now). Prompt: {prompt!r}"
+    )
+    assert not hasattr(fs, "fetch_sonar_status"), (
+        "fleet_supervisor still exposes fetch_sonar_status — dead code "
+        "should have been removed in Agency_OS-6b2s."
+    )
+    assert not hasattr(fs, "_format_sonar_brief"), (
+        "fleet_supervisor still exposes _format_sonar_brief — dead code "
+        "should have been removed in Agency_OS-6b2s."
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`Agency_OS-6b2s` — drop the dead SonarCloud fetch/format helpers from `fleet_supervisor.py` and the four KEI-189 sonar tests that exercised them. SonarCloud's CI workflow was removed in PR #1138 and **no SonarCloud check has fired on any Agency_OS PR since** (verified across PRs #1414, #1416, #1420, #1424, #1429, #1431 — zero `SonarCloud Code Analysis` in `gh pr view --json statusCheckRollup`). CodeQL is the sole code-analysis gate.

`build_review_prompt` was still calling `fetch_sonar_status` on every PR review, burning two HTTP timeouts to `sonarcloud.io/api` and logging warnings — live code calling a dead API.

## Removed

- `_SONAR_PROJECT_KEY`, `_SONAR_BASE` (constants).
- `fetch_sonar_status` (KEI-189 dual-endpoint helper).
- `_format_sonar_brief` (no callers post-cleanup).
- `sonar_block` injection inside `build_review_prompt`. Reviewer instruction is now "check CI" alone.
- Five tests: `test_fetch_sonar_status_returns_both_dimensions`, `test_fetch_sonar_status_fail_open`, `test_format_sonar_brief_renders_both_endpoints`, `test_format_sonar_brief_empty_when_no_data`, `test_build_review_prompt_includes_sonar_block`.

## Added (regression catch)

`test_build_review_prompt_no_longer_calls_sonar` asserts:
1. `build_review_prompt` output does not contain `"sonar"` (case-insensitive).
2. `fleet_supervisor` does NOT re-export `fetch_sonar_status` / `_format_sonar_brief`.

So an accidental re-introduction of the dead helpers (e.g. via a copy-from-old-branch merge) fails CI.

## What this PR does NOT do

**GitHub App removal.** The dispatch's `gh api DELETE /repos/Keiracom/Agency_OS/installations/...` path requires GitHub App JWT auth (the `installations` endpoint is not reachable with a user PAT on a user-owned repo — verified, returns 401 "JSON web token could not be decoded"). The SonarCloud GitHub App needs to be uninstalled via the web UI at `https://github.com/settings/installations` (user-account scope on Dave's GitHub user, not repo scope). However: **with no workflow to invoke its action, the App is inert** — no checks fire, no statuses post. This PR closes the live-code surface; the App-removal step is purely housekeeping at this point.

Recommended follow-up: Dave or Elliot opens `https://github.com/settings/installations`, clicks `SonarCloud` → `Configure` → `Uninstall` (single-click confirmation). Optional, low priority.

## Verbatim verify

```
$ PYTHONPATH=/home/elliotbot/clawd/Agency_OS python3 -m pytest tests/scripts/test_fleet_supervisor.py -v
…
tests/scripts/test_fleet_supervisor.py::test_build_review_prompt_no_longer_calls_sonar PASSED [ 82%]
…
============================== 73 passed in 1.20s ==============================
```

5 sonar tests removed, 1 regression catch added, net 72 → 73 tests. `ruff check` + `ruff format --check` green.

## Other sonar refs in the repo (deliberately untouched)

- `scripts/classifier/discovery_log_classifier.py:93-94` — `"sonar"`, `"sonarcloud"` as classifier KEYWORDS for tagging historical discovery logs. Still useful for matching past entries; safe to keep.
- `scripts/smoke_test_skill_gen.py:38` — `("sonarcloud", "SonarCloud bot comment retrieval")` in a hard-requirements list. Used to validate generated skills; the skill is a historical reference. Out of scope for this PR.
- `scripts/hooks/elliot_stop_hook.py:44` — regex pattern `dual.?sonar` in review-chatter detection. Catches historical Slack chatter; safe to keep.

ref: `Agency_OS-6b2s`
🤖 Atlas — Tier A build clone (engineering execution)