### PR TITLE
[NOVA] postgres_self_hosted built->proven: live R/W roundtrip proof + contract (gate 5cb0d0de)

### DIFF
--- a/scripts/proof_bar/_live_roundtrip_probe.sql
+++ b/scripts/proof_bar/_live_roundtrip_probe.sql
@@ -1,0 +1,55 @@
+-- _live_roundtrip_probe.sql — invoked by postgres_self_hosted_live_roundtrip.sh.
+--
+-- LIVE read+write proof of the self-hosted (Vultr VPS) Postgres. Performs a
+-- REAL durable write of a unique sentinel token (passed as :token), reads it
+-- back, asserts equality FROM the live server, prints server identity, then
+-- deletes the sentinel so the proof is idempotent and re-runnable.
+--
+-- This is intentionally NOT wrapped in a rollback: a rollback would prove
+-- only that a transaction can open, not that the instance durably persists a
+-- committed row. The DELETE at the end restores a clean state.
+--
+-- ON_ERROR_STOP=1 is set by the wrapper: any failure (connect, write, read)
+-- aborts with non-zero exit, which the wrapper treats as proof failure.
+
+\set QUIET on
+
+-- Durable liveness table on the self-hosted instance (created once).
+CREATE TABLE IF NOT EXISTS public.gate_proof_liveness (
+    id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    token      text NOT NULL,
+    written_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Expose the token to plpgsql (the DO block below reads it via current_setting).
+SET myapp.tok = :'token';
+
+-- Real durable write (committed — psql autocommits each statement).
+INSERT INTO public.gate_proof_liveness (token) VALUES (:'token');
+
+-- Server identity — proves which live instance answered.
+SELECT 'current_database=' || current_database() AS db;
+SELECT 'server_addr=' || COALESCE(host(inet_server_addr()), 'local') AS addr;
+SELECT 'server_version=' || current_setting('server_version') AS ver;
+
+-- Read the sentinel back and assert it round-tripped from the live DB.
+SELECT CASE
+         WHEN count(*) = 1 THEN 'sentinel_readback_match=true'
+         ELSE 'sentinel_readback_match=false'
+       END AS readback
+FROM public.gate_proof_liveness
+WHERE token = :'token';
+
+-- Hard assert: abort (non-zero exit via ON_ERROR_STOP) if the row is absent.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM public.gate_proof_liveness
+        WHERE token = current_setting('myapp.tok', true)
+    ) THEN
+        RAISE EXCEPTION 'live readback failed: sentinel token not found on live server';
+    END IF;
+END $$;
+
+-- Idempotent cleanup — remove this run's sentinel.
+DELETE FROM public.gate_proof_liveness WHERE token = :'token';

--- a/scripts/proof_bar/postgres_self_hosted_live_roundtrip.sh
+++ b/scripts/proof_bar/postgres_self_hosted_live_roundtrip.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# postgres_self_hosted_live_roundtrip.sh
+#
+# LIVE proof for gate_roadmap id=5cb0d0de-6aae-4e85-92e0-8fadddc1d7f3
+# (component=postgres_self_hosted). Bound as the proof_gate_contract.cmd
+# value — running this script against the self-hosted (Vultr VPS) Postgres
+# produces the contract-required run_output substrings:
+#   - "LIVE_HOST_CONFIRMED="        (host is the VPS, NOT *.supabase.co)
+#   - "sentinel_readback_match=true" (durable write read back from live DB)
+#   - "LIVE_ROUNDTRIP_OK"           (full connect->write->read->assert passed)
+#
+# Mechanism: connects to VULTR_POSTGRES_DSN (the self-hosted instance — NOT
+# DATABASE_URL, which still points at Supabase), then runs
+# _live_roundtrip_probe.sql which performs a REAL durable write of a unique
+# sentinel token, reads it back, asserts equality from the live server, and
+# deletes the sentinel (idempotent). This is a live R/W proof — not a mock,
+# not pytest. A Supabase DSN is refused so the managed DB cannot masquerade
+# as the self-hosted proof.
+#
+# Exit code: 0 on a verified live roundtrip; 2 if a required token is
+# missing (proof failed); 3 on environment errors (no/invalid DSN).
+#
+# ref: NOVA postgres_self_hosted built->proven (gate 5cb0d0de).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The self-hosted DSN must come from VULTR_POSTGRES_DSN. We deliberately do
+# NOT fall back to DATABASE_URL — that is Supabase and would prove the wrong
+# instance.
+if [[ -z "${VULTR_POSTGRES_DSN:-}" ]]; then
+    if [[ -f /home/elliotbot/.config/agency-os/.env ]]; then
+        # shellcheck disable=SC1091
+        source /home/elliotbot/.config/agency-os/.env
+    fi
+fi
+
+if [[ -z "${VULTR_POSTGRES_DSN:-}" ]]; then
+    echo "ERROR: VULTR_POSTGRES_DSN is not set — cannot prove the self-hosted Postgres" >&2
+    exit 3
+fi
+
+DSN="${VULTR_POSTGRES_DSN//postgresql+asyncpg/postgresql}"
+
+# Extract host; refuse Supabase so the proof can only pass against self-hosted.
+HOST="$(python3 - "$DSN" <<'PY'
+import sys, urllib.parse as u
+print((u.urlparse(sys.argv[1]).hostname or ""))
+PY
+)"
+
+if [[ -z "$HOST" ]]; then
+    echo "ERROR: could not parse host from VULTR_POSTGRES_DSN" >&2
+    exit 3
+fi
+if [[ "$HOST" == *supabase* ]]; then
+    echo "ERROR: VULTR_POSTGRES_DSN host is Supabase ($HOST) — refusing; this proof requires the self-hosted instance" >&2
+    exit 3
+fi
+
+echo "LIVE_HOST_CONFIRMED=$HOST"
+
+# Unique sentinel token for this run (no Date/random in SQL — generated here).
+TOKEN="nova-pgproof-$(date -u +%Y%m%dT%H%M%SZ)-$$-${RANDOM}"
+
+PROBE_OUT="$(psql "$DSN" -v ON_ERROR_STOP=1 -v token="$TOKEN" \
+    -f "$SCRIPT_DIR/_live_roundtrip_probe.sql" 2>&1)"
+PROBE_RC=$?
+
+echo "$PROBE_OUT"
+
+if [[ "$PROBE_RC" -ne 0 ]]; then
+    echo "ERROR: live probe exited non-zero ($PROBE_RC)" >&2
+    exit 2
+fi
+
+if ! echo "$PROBE_OUT" | grep -F -q -- "sentinel_readback_match=true"; then
+    echo "MISSING REQUIRED TOKEN: sentinel_readback_match=true" >&2
+    exit 2
+fi
+
+# Gated on a real readback against the live host.
+echo "LIVE_ROUNDTRIP_OK"
+exit 0

--- a/supabase/migrations/20260603_postgres_self_hosted_proof_gate.sql
+++ b/supabase/migrations/20260603_postgres_self_hosted_proof_gate.sql
@@ -1,0 +1,62 @@
+-- 20260603_postgres_self_hosted_proof_gate.sql
+--
+-- NOVA — postgres_self_hosted built->proven prep (gate id 5cb0d0de).
+--
+-- Sets the proof_gate_contract + stamps built_by_callsign='nova' on the live
+-- gate_roadmap row for component=postgres_self_hosted. Does NOT flip status:
+-- the flip happens only after the LIVE proof runs against the self-hosted
+-- (Vultr) Postgres and Aiden + Max each record a binding_reviewer proof_run.
+--
+-- Scope (ratified Dave/Elliot 2026-06-03): this gate proves the self-hosted
+-- instance is REAL, reachable, and durably writable (live connect + write +
+-- read-back + assert). It does NOT cover Supabase decommission or
+-- backup/restore — that is the separate R2 offsite-backup hard gate (KEI-242),
+-- tracked independently. proof_gate wording is narrowed here to match.
+--
+-- The contract.cmd binds to scripts/proof_bar/postgres_self_hosted_live_roundtrip.sh.
+-- expected_output_contains are substrings that ONLY a live roundtrip against a
+-- non-Supabase host can produce (LIVE_HOST_CONFIRMED + sentinel_readback_match
+-- + LIVE_ROUNDTRIP_OK) — a mock / pytest-only run cannot satisfy them.
+
+BEGIN;
+
+-- Stamp the builder (idempotent — only if not already set).
+SET LOCAL agency_os.callsign = 'nova';
+UPDATE public.gate_roadmap
+   SET built_by_callsign = 'nova'
+ WHERE id = '5cb0d0de-6aae-4e85-92e0-8fadddc1d7f3'
+   AND component = 'postgres_self_hosted'
+   AND built_by_callsign IS NULL;
+
+-- Set the proof contract + narrow the proof_gate to the live-roundtrip scope.
+UPDATE public.gate_roadmap
+   SET proof_gate = 'Self-hosted Postgres on the Vultr VPS is real, reachable, '
+                 || 'and durably writable: a live connection performs a real '
+                 || 'write + read-back + assert against the live server (not a '
+                 || 'mock). Supabase decommission + backup/restore are the '
+                 || 'separate R2 offsite-backup hard gate (KEI-242).',
+       proof_gate_contract = '{
+            "check_id": "postgres_self_hosted_live_roundtrip_v1",
+            "cmd": "bash scripts/proof_bar/postgres_self_hosted_live_roundtrip.sh",
+            "expected_output_contains": [
+                "LIVE_HOST_CONFIRMED=",
+                "sentinel_readback_match=true",
+                "LIVE_ROUNDTRIP_OK"
+            ],
+            "role_sep": {"builder": "nova", "attester": ["aiden", "max"]},
+            "negative_test_required": true
+        }'::jsonb,
+       required_attestation_kind = 'binding_reviewer'
+ WHERE id = '5cb0d0de-6aae-4e85-92e0-8fadddc1d7f3'
+   AND component = 'postgres_self_hosted';
+
+COMMIT;
+
+-- NOTE: status flip is performed AFTER the live proof + dual attestation:
+--   1. Aiden runs `bash scripts/proof_bar/postgres_self_hosted_live_roundtrip.sh`
+--      in his own session against VULTR_POSTGRES_DSN -> binding_reviewer proof_run.
+--   2. Max does likewise (independent session).
+--   3. UPDATE public.gate_roadmap SET status='proven', proof_run_id=<run>
+--        WHERE id='5cb0d0de-6aae-4e85-92e0-8fadddc1d7f3';
+--      fires trg_01 (Checks A/B/C) + trg_11 (aiden+max dual-attest) +
+--      trg_02 (forward-only) + trg_04 (attester != builder=nova). All must pass.


### PR DESCRIPTION
## Gate 5cb0d0de — component \`postgres_self_hosted\` (phase 4_infra), built -> proven

LIVE proof harness for the self-hosted (Vultr VPS) Postgres. Mirrors the
\`product_proof_enforcement_live_rejection\` proof_bar pattern.

### What this proves
Self-hosted Postgres is **real, reachable, and durably writable** — a live connection
does a real **write + read-back + assert** against the live server. Not a mock, not
pytest-only (those are disqualified). Supabase decommission + backup/restore are the
**separate R2 offsite-backup hard gate (KEI-242)** — out of scope here per Dave/Elliot
ratification 2026-06-03.

### Files
- \`scripts/proof_bar/postgres_self_hosted_live_roundtrip.sh\` — connects to
  \`VULTR_POSTGRES_DSN\` (refuses \`*.supabase.co\` so the managed DB can't masquerade),
  runs the probe, gates on a live readback. Emits contract substrings:
  \`LIVE_HOST_CONFIRMED=\`, \`sentinel_readback_match=true\`, \`LIVE_ROUNDTRIP_OK\`.
- \`scripts/proof_bar/_live_roundtrip_probe.sql\` — durable write -> server identity ->
  read-back -> hard-assert -> idempotent cleanup.
- \`supabase/migrations/20260603_postgres_self_hosted_proof_gate.sql\` — stamps
  \`built_by_callsign='nova'\`, sets \`proof_gate_contract.cmd\`, narrows \`proof_gate\`.
  **Does NOT flip status.**

### Mechanical validation (harness self-test, NOT the gate proof)
Probe SQL run against a real Postgres: \`psql_exit=0\`, \`sentinel_readback_match=true\`,
cleanup confirmed (0 rows). Guards verified: no-DSN -> exit 3; Supabase host -> refused
exit 3.

### ⛔ BLOCKER — cannot run the gate proof yet
\`VULTR_POSTGRES_DSN\` (host + creds for the self-hosted instance) is set in **no store
I can access**: not in \`~/.config/agency-os/.env*\`, not in systemd units, not in Vault
(25 vendor paths, no vultr/postgres entry), and the Vultr API reports **0 managed
databases**. The live runtime + all backup scripts still point at Supabase. The
component is marked \`built\` on the strength of KEI-241 migration *code*, not a
wired-up live instance.

**To unblock (one input):** provide \`VULTR_POSTGRES_DSN\` (or confirm which of the 3
VPS — \`149.28.182.216\` / vault / temporal — runs Postgres + the creds path). Then:
1. Apply the migration (stamp + contract).
2. Aiden runs \`bash scripts/proof_bar/postgres_self_hosted_live_roundtrip.sh\` in his
   own session -> \`binding_reviewer\` proof_run.
3. Max runs it likewise (independent session).
4. \`UPDATE gate_roadmap SET status='proven', proof_run_id=<run> WHERE id='5cb0d0de...'\`
   — fires trg_01 (A/B/C) + trg_11 (aiden+max dual-attest) + trg_02 (forward-only) +
   trg_04 (attester != builder=nova).

### Review
Orchestrator-merge-after-NATS-concur: 2-of-3 deliberator concur (Elliot/Aiden/Max),
attester != builder (nova). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)