### PR TITLE
[SCOUT] feat(proof_gate): docker_runtime LIVE proof — real build+run + contract + built_by=scout

### DIFF
--- a/scripts/proof_bar/docker_runtime_live_proof.sh
+++ b/scripts/proof_bar/docker_runtime_live_proof.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# docker_runtime_live_proof.sh
+#
+# LIVE proof for gate_roadmap component docker_runtime
+# (id = ec883620-ee1c-454b-ba31-0263fd93aaa6, phase 4_infra).
+#
+# Performs a REAL `docker build` + `docker run` and asserts the results FROM
+# the runtime — this is NOT a mock and NOT a pytest. Bound to the gate row as
+# proof_gate_contract.cmd. trg_01 fn_verify_before_proven Check A pins
+# gate_proof_runs.run_cmd to EXACTLY:
+#     bash scripts/proof_bar/docker_runtime_live_proof.sh
+# so any pytest/mock run_cmd fails Check A (cmd_mismatch) — the structural
+# negative bar. A mock also cannot produce real `docker build`/`docker run`
+# stdout, which is what the assertions below grep for.
+#
+# Emits each DOCKER_RUNTIME_PROOF token (the contract.expected_output_contains
+# substrings) ONLY after its real assertion passes.
+#
+# Exit 0 = every assertion passed (the runtime works, unmocked).
+# Exit 2 = a required assertion/token was missing (proof failed).
+# Exit 3 = environment error (no docker / daemon unreachable).
+#
+# Footprint: builds FROM the locally-cached postgres:16-alpine base via a
+# stdin Dockerfile with an empty context (no registry pull, one tiny layer);
+# removes the throwaway image on exit. hello-world is also cached locally.
+#
+# ref: scout-docker-runtime-live-proof.
+
+set -u
+
+TAG="docker-runtime-proof:scout-$$"
+BAKED="DOCKER_BUILD_LAYER_MARKER_a1b2c3"
+
+cleanup() { docker rmi -f "$TAG" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+fail() { echo "DOCKER_RUNTIME_PROOF: FAIL — $1" >&2; exit "${2:-2}"; }
+
+command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not on PATH" >&2; exit 3; }
+docker info >/dev/null 2>&1 || { echo "ERROR: docker daemon unreachable" >&2; exit 3; }
+
+# ── 1. host_user assertion (proof_gate prose: "succeeds as elliotbot") ───────
+HOST_USER="$(id -un)"
+[[ "$HOST_USER" == "elliotbot" ]] || fail "host_user=$HOST_USER != elliotbot"
+echo "DOCKER_RUNTIME_PROOF: host_user=elliotbot OK"
+
+# ── 2. real BUILD — build-time RUN bakes a marker file into a new layer ──────
+BUILD_OUT="$(printf 'FROM postgres:16-alpine\nRUN echo %s > /proof_marker.txt\n' "$BAKED" \
+            | docker build -t "$TAG" - 2>&1)" \
+    || { echo "$BUILD_OUT"; fail "docker build failed" 2; }
+echo "$BUILD_OUT" | tail -2
+IMG_ID="$(docker images --no-trunc --format '{{.ID}}' "$TAG" 2>/dev/null)"
+[[ -n "$IMG_ID" ]] || fail "built image not found after build"
+echo "DOCKER_RUNTIME_PROOF: build OK image=$IMG_ID"
+
+# ── 3. real RUN — assert baked marker + runtime exec token FROM container ────
+RUN_OUT="$(docker run --rm "$TAG" sh -c 'cat /proof_marker.txt; echo RUNTIME_EXEC_TOKEN; uname -s' 2>&1)" \
+    || { echo "$RUN_OUT"; fail "docker run failed" 2; }
+echo "--- container stdout ---"
+echo "$RUN_OUT"
+echo "--- end container stdout ---"
+echo "$RUN_OUT" | grep -qF "$BAKED"            || fail "baked build marker absent from container stdout"
+echo "$RUN_OUT" | grep -qF "RUNTIME_EXEC_TOKEN" || fail "runtime exec token absent from container stdout"
+echo "$RUN_OUT" | grep -qF "Linux"             || fail "uname -s != Linux from inside container"
+echo "DOCKER_RUNTIME_PROOF: run-marker asserted-from-runtime OK"
+
+# ── 4. hello-world (proof_gate prose: "docker run hello-world succeeds") ─────
+HW_OUT="$(docker run --rm hello-world 2>&1)" \
+    || { echo "$HW_OUT"; fail "hello-world run failed" 2; }
+echo "$HW_OUT" | grep -qF "Hello from Docker!" || fail "hello-world greeting absent"
+echo "DOCKER_RUNTIME_PROOF: hello-world OK"
+
+# ── 5. uniqueness line (distinct run_output → distinct output_sha256 so the
+#       UNIQUE(gate_roadmap_id, output_sha256) constraint never collides
+#       between the aiden and max attestation runs) + final token ────────────
+echo "DOCKER_RUNTIME_PROOF: run_nonce=$(date -u +%Y%m%dT%H%M%S.%N)"
+echo "DOCKER_RUNTIME_PROOF: server_version=$(docker version --format '{{.Server.Version}}' 2>/dev/null)"
+echo "DOCKER_RUNTIME_PROOF: ALL PASS"
+exit 0

--- a/supabase/migrations/20260603_docker_runtime_proof_contract.sql
+++ b/supabase/migrations/20260603_docker_runtime_proof_contract.sql
@@ -1,0 +1,178 @@
+-- ============================================================================
+-- 20260603_docker_runtime_proof_contract.sql
+--
+-- Arms the docker_runtime gate (gate_roadmap id
+-- ec883620-ee1c-454b-ba31-0263fd93aaa6, phase 4_infra) for a LIVE built→proven
+-- attestation. KEI ref: scout-docker-runtime-live-proof.
+--
+-- WHAT THIS MIGRATION DOES
+--   1. Stamps gate_roadmap.built_by_callsign = 'scout' on the docker_runtime
+--      row. It was NULL — which left the attester≠builder gate UNARMED:
+--        - trg_04 fn_gate_proof_no_self_attest RAISEs on NULL built_by_callsign
+--          ("record the build transition first"), so NO binding_reviewer
+--          proof_run could be inserted at all;
+--        - the PR #1415 watchdog keys on built_by_callsign for structural
+--          attester≠builder enforcement.
+--      Per Elliot addendum 2026-06-03 the stamp value is 'scout' (the author of
+--      this proof mechanism). The physical infra owner stays atlas in the
+--      owner column. OLD.built_by_callsign IS NULL so the trg_03 immutability
+--      branch does not fire; the UPDATE-path capture branch only fires on a
+--      status transition to 'built', which this UPDATE is not — so the explicit
+--      value passes through.
+--
+--   2. Attaches the structured proof_gate_contract:
+--        cmd  = bash scripts/proof_bar/docker_runtime_live_proof.sh
+--        expected_output_contains = the five DOCKER_RUNTIME_PROOF tokens that
+--          the script emits ONLY after each real `docker build` / `docker run`
+--          assertion passes.
+--        role_sep.builder = scout, attester = [aiden, max].
+--      Because trg_01 Check A pins run_cmd to contract.cmd EXACTLY, a
+--      pytest/mocked run_cmd is disqualified structurally (cmd_mismatch). This
+--      is the directive's NEGATIVE bar: pytest-only/mocked = disqualified.
+--
+--   3. Inline DO-block negative self-test (Dave 2026-06-02 standing precedent,
+--      same inner-sentinel-raise / outer-rollback pattern as the BASE +
+--      trigger-fix migrations — gate_proof_runs is append-only, trg_07 refuses
+--      DELETE): asserts trg_01 Check A REFUSES a mismatched-cmd proof_run flip
+--      against a docker_runtime-shaped contract. If the trigger fails to block,
+--      the migration ABORTS.
+--
+-- NON-GOALS (by design):
+--   - The built→proven flip itself. trg_11 requires BOTH aiden AND max
+--     binding_reviewer proof_runs, and trg_08 write_guard means only aiden's
+--     and max's own sessions can insert them. The flip is the dual-attest step
+--     that follows this PR, not part of it.
+--   - Any change to the trigger functions (correct as of #1424).
+-- ============================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1 + 2. Stamp built_by_callsign='scout' and attach the proof_gate_contract.
+-- ---------------------------------------------------------------------------
+
+SET LOCAL agency_os.callsign = 'scout';
+
+UPDATE public.gate_roadmap
+   SET built_by_callsign = 'scout',
+       proof_gate_contract = '{
+        "check_id": "docker_runtime_live_v1",
+        "cmd": "bash scripts/proof_bar/docker_runtime_live_proof.sh",
+        "expected_output_contains": [
+            "DOCKER_RUNTIME_PROOF: host_user=elliotbot OK",
+            "DOCKER_RUNTIME_PROOF: build OK",
+            "DOCKER_RUNTIME_PROOF: run-marker asserted-from-runtime OK",
+            "DOCKER_RUNTIME_PROOF: hello-world OK",
+            "DOCKER_RUNTIME_PROOF: ALL PASS"
+        ],
+        "role_sep": {
+            "builder": "scout",
+            "attester": ["aiden", "max"]
+        },
+        "negative_test_required": true
+   }'::jsonb,
+       notes = COALESCE(notes, '') || E'\n\n[scout-docker-runtime-live-proof 2026-06-03] '
+            || 'Stamped built_by_callsign=scout (was NULL — armed trg_04 + PR '
+            || '#1415 watchdog; physical infra owner remains atlas). Attached '
+            || 'proof_gate_contract check_id=docker_runtime_live_v1. cmd is the '
+            || 'live proof_bar script (real docker build + run, asserted from '
+            || 'the runtime). expected_output_contains targets the five '
+            || 'DOCKER_RUNTIME_PROOF tokens the script emits only after each '
+            || 'real assertion passes. trg_01 Check A pins run_cmd to cmd '
+            || 'exactly, so pytest/mocked evidence is disqualified. proven-flip '
+            || 'requires aiden + max binding_reviewer proof_runs (dual-attest).'
+ WHERE id = 'ec883620-ee1c-454b-ba31-0263fd93aaa6'::uuid;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. Inline DO-block negative self-test — trg_01 Check A MUST refuse a
+--    mismatched-cmd proof_run flip. Transient fixtures rolled back via the
+--    sentinel-raise / outer-EXCEPTION pattern (append-only table; no DELETE).
+-- ---------------------------------------------------------------------------
+
+DO $self_test$
+DECLARE
+    v_gate_id       uuid := gen_random_uuid();
+    v_run_id        uuid;
+    v_session_uuid  uuid := gen_random_uuid();
+    v_msg           text;
+BEGIN
+    BEGIN  -- outer sub-tx: fixtures roll back when the sentinel below fires
+        SET LOCAL agency_os.callsign = 'atlas';
+        INSERT INTO public.gate_roadmap (
+            id, component, phase, subphase, proof_gate, proof_gate_contract,
+            status, required_attestation_kind, owner
+        ) VALUES (
+            v_gate_id,
+            'docker_runtime_INLINE_NEGTEST_' || replace(v_gate_id::text, '-', ''),
+            '0_foundation', 'gates',
+            'inline docker_runtime contract self-test row',
+            '{
+                "check_id": "docker_runtime_inline_self_test",
+                "cmd": "bash scripts/proof_bar/docker_runtime_live_proof.sh",
+                "expected_output_contains": ["DOCKER_RUNTIME_PROOF: ALL PASS"],
+                "role_sep": {"builder": "atlas", "attester": ["aiden"]},
+                "negative_test_required": true
+            }'::jsonb,
+            'built',
+            'binding_reviewer',
+            'atlas'
+        );
+
+        -- trg_06 session-independence needs a tool_call_log row for the
+        -- attester's session_uuid (present in attester, absent in builder).
+        INSERT INTO public.tool_call_log (callsign, session_uuid, tool_name, started_at)
+        VALUES ('aiden', v_session_uuid, 'docker_runtime_self_test_inline', now());
+
+        SET LOCAL agency_os.callsign = 'aiden';
+        INSERT INTO public.gate_proof_runs (
+            gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+            exit_code, attesting_callsign, attester_session_uuid
+        ) VALUES (
+            v_gate_id,
+            'binding_reviewer',
+            'pytest tests/some_mock_test.py -v',  -- WRONG cmd (the disqualified pytest shape)
+            'mocked output claiming DOCKER_RUNTIME_PROOF: ALL PASS but run_cmd is pytest not the script',
+            repeat('d', 64),
+            0,
+            'aiden',
+            v_session_uuid::text
+        ) RETURNING id INTO v_run_id;
+
+        SET LOCAL agency_os.callsign = 'dave';
+        BEGIN  -- inner sub-tx: catches the expected check_violation
+            UPDATE public.gate_roadmap
+               SET status = 'proven', proof_run_id = v_run_id
+             WHERE id = v_gate_id;
+            RAISE EXCEPTION
+                'DOCKER_RUNTIME_SELF_TEST FAIL: UPDATE proven accepted; trg_01 was expected to refuse on Check A cmd mismatch (pytest run_cmd != contract.cmd)'
+                USING ERRCODE = 'check_violation';
+        EXCEPTION WHEN check_violation THEN
+            GET STACKED DIAGNOSTICS v_msg = MESSAGE_TEXT;
+            IF v_msg NOT LIKE '%proof_gate_contract Check A%' THEN
+                RAISE EXCEPTION
+                    'DOCKER_RUNTIME_SELF_TEST FAIL: unexpected check_violation (wanted Check A cmd_mismatch): %', v_msg
+                    USING ERRCODE = 'check_violation';
+            END IF;
+            -- happy path: Check A raised exactly as expected; fall through
+        END;
+
+        RAISE EXCEPTION 'DOCKER_RUNTIME_SELF_TEST_OK' USING ERRCODE = 'check_violation';
+    EXCEPTION WHEN check_violation THEN
+        GET STACKED DIAGNOSTICS v_msg = MESSAGE_TEXT;
+        IF v_msg = 'DOCKER_RUNTIME_SELF_TEST_OK' THEN
+            RAISE NOTICE
+                'INLINE SELF-TEST PASS: trg_01 Check A refused pytest-shaped run_cmd; fixtures rolled back via outer sub-tx';
+        ELSE
+            RAISE EXCEPTION 'INLINE SELF-TEST FAIL or unexpected error: %', v_msg;
+        END IF;
+    END;
+END
+$self_test$;
+
+
+COMMIT;
+
+-- ============================================================================
+-- end of 20260603_docker_runtime_proof_contract.sql
+-- ============================================================================


### PR DESCRIPTION
## What

Arms the `docker_runtime` gate (`gate_roadmap` id `ec883620-ee1c-454b-ba31-0263fd93aaa6`, phase 4_infra, status=built) for a **LIVE** built→proven attestation: a real `docker build` + `docker run` asserted from the runtime. **NOT a mock, NOT pytest.**

## Files

1. **`scripts/proof_bar/docker_runtime_live_proof.sh`** — the live proof. Real `docker build` (build-time `RUN` bakes a marker into a new layer, `FROM` cached `postgres:16-alpine` via a stdin Dockerfile + empty context → no registry pull) then real `docker run` asserting, from actual container stdout: the baked build marker, a runtime-exec token, and `uname -s`=Linux. Also runs `hello-world` (asserts `Hello from Docker!`) and `host_user=elliotbot` (proof_gate prose). Emits 5 `DOCKER_RUNTIME_PROOF` tokens only after each real assertion passes; exit 0 on full pass, 2 on missing assertion, 3 on env error.
2. **`supabase/migrations/20260603_docker_runtime_proof_contract.sql`** — stamps `built_by_callsign='scout'` (was NULL — armed `trg_04` no-self-attest + PR #1415 watchdog; `owner` stays `atlas`), attaches `proof_gate_contract` (cmd=the bash script, the 5 expected tokens, `role_sep` builder=scout attester=[aiden,max]). Inline DO-block negative self-test proves `trg_01` Check A refuses a pytest-shaped `run_cmd` — **PASS at apply** (fixtures rolled back via sentinel-raise).

## Negative bar (structural)

`trg_01` Check A pins `gate_proof_runs.run_cmd` to `contract.cmd` **exactly** (`bash scripts/proof_bar/docker_runtime_live_proof.sh`). Any `pytest …`/mocked run_cmd → `cmd_mismatch` RAISE. A mock also cannot produce real `docker build`/`docker run` stdout, which the assertions grep for. **pytest-only/mocked = disqualified.**

## Flip path (post-merge, dual-attest — NOT in this PR)

Builder (scout) cannot insert the attesters' proof_runs (`trg_08` write_guard). **Aiden** and **Max** each run the script in their own session, record a `binding_reviewer` proof_run (exit_code=0; `attester_session_uuid` present in their own `tool_call_log`, absent from scout's per `trg_06`), then flip `status='proven'` — which passes `trg_01` A/B/C against the pinned run and `trg_11` (both aiden AND max present).

## Verbatim live proof_run (scout, this branch)

```
DOCKER_RUNTIME_PROOF: host_user=elliotbot OK
Successfully built e7ae0add28af
Successfully tagged docker-runtime-proof:scout-57930
DOCKER_RUNTIME_PROOF: build OK image=sha256:e7ae0add28aff6c5962dbdd79c92bae8c12418257062479f4120b1adfbcbb793
--- container stdout ---
DOCKER_BUILD_LAYER_MARKER_a1b2c3
RUNTIME_EXEC_TOKEN
Linux
--- end container stdout ---
DOCKER_RUNTIME_PROOF: run-marker asserted-from-runtime OK
DOCKER_RUNTIME_PROOF: hello-world OK
DOCKER_RUNTIME_PROOF: run_nonce=20260603T193855.875567181
DOCKER_RUNTIME_PROOF: server_version=29.1.3
DOCKER_RUNTIME_PROOF: ALL PASS
EXIT CODE: 0
```

## Note — owner anomaly (surfaced to Elliot)

During apply, `owner` transiently flipped `atlas`→`scout` between migration apply and verify, despite no DB trigger/default/generated-column referencing `owner` (verified). A controlled re-set to `atlas` held stable through a commit → no DB-level coercion. Most likely an external background sync (PR #1415 watchdog keys on `built_by_callsign`). Restored `owner=atlas`; not load-bearing for attestation (gate keys on `built_by_callsign`). Flagged for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)