### PR TITLE
[SCOUT] fix(kei_duplicate_detector): neuter Linear commentCreate writer (Linear retirement)

### DIFF
--- a/scripts/kei_duplicate_detector.py
+++ b/scripts/kei_duplicate_detector.py
@@ -129,6 +129,13 @@ def _post_linear_comment(
 ) -> bool:
     """Linear GraphQL commentCreate. Returns True on ok=true, else False.
     Best-effort: any network/JSON failure returns False without raising."""
+    # Linear retirement (Dave 2026-06-03 "we don't need linear"): commentCreate
+    # is suppressed by default — no mutation is POSTed. Reversible via
+    # LINEAR_RETIRED=0. governance_hooks.py also blocks Linear write mutations at
+    # the PreToolUse hook (defense-in-depth). Returns False (best-effort: comment
+    # not posted), which all callers already tolerate.
+    if os.environ.get("LINEAR_RETIRED", "1") != "0":
+        return False
     query = (
         "mutation Comment($issueId: String!, $body: String!) {"
         "  commentCreate(input: {issueId: $issueId, body: $body}) {"


### PR DESCRIPTION
## What

Part of the Linear full-retirement tail (Dave 2026-06-03: "we don't need linear") — **script-guard 2 of 2**.

`scripts/kei_duplicate_detector.py` `_post_linear_comment()` POSTed a `commentCreate` mutation to Linear. This neuters it: a `LINEAR_RETIRED` guard (default retired) returns `False` **before** any Linear write.

## Why it's safe

- **Reversible** — flip `LINEAR_RETIRED=0` to restore.
- Returns `False`, which the function already documents as a best-effort outcome all callers tolerate ("any network/JSON failure returns False without raising").
- Read-side duplicate detection untouched.
- `governance_hooks.py` already blocks Linear write mutations at the PreToolUse hook — aligns code with that enforcement (defense-in-depth).

## Scope

One guarded early-return; `ast.parse` syntax-checked. Bounded, reversible. Pairs with the betterstack writer guard (#1444); session-start doc retirement folded into #1439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)