### PR TITLE
[NOVA] style(kv_resolver): ruff format fix — unblocks repo-wide CI (Backend Lint)

### DIFF
--- a/src/keiracom_system/vault/kv_resolver.py
+++ b/src/keiracom_system/vault/kv_resolver.py
@@ -122,8 +122,8 @@ SECRET_MANIFEST: tuple[tuple[str, str, str], ...] = (
 # env var by resolve_into_env after the manifest pass.
 #   alias_env_var -> canonical_env_var
 SECRET_ALIASES: dict[str, str] = {
-    "SUPABASE_DB_DSN": "DATABASE_URL",   # env: "copied from DATABASE_URL"
-    "OPENAI_APIKEY": "OPENAI_API_KEY",   # typo-variant; flagged for code cleanup
+    "SUPABASE_DB_DSN": "DATABASE_URL",  # env: "copied from DATABASE_URL"
+    "OPENAI_APIKEY": "OPENAI_API_KEY",  # typo-variant; flagged for code cleanup
 }
 
 


### PR DESCRIPTION
## Root cause of the #1448 (and all-PR) ruff failure

`Backend Lint (Ruff)` runs `ruff format src/ --check` **repo-wide**. My Phase 1 PR (#1443, merged to main as `3d9216f3`) added two inline comments with a 3-space gap before `#`; ruff format wants 2. So **main's `kv_resolver.py` fails the format check**, failing CI on every open PR — not just #1448.

**This is NOT a #1448 file** (#1448 is docs-only). And it could **not** be fixed on the #1448 branch: that branch is based on *pre-#1443* main, so committing `kv_resolver.py` there would revert #1443's 32 manifest entries. This PR is off **current** main, so the 72-entry manifest + aliases stay intact.

### Change
2-line inline-comment spacing (3→2 spaces). Pure format, no logic.
```
ruff format --check src/keiracom_system/vault/kv_resolver.py  → already formatted
ruff check src/keiracom_system/vault/kv_resolver.py           → All checks passed!
```

### Effect
Merging this formats main's `kv_resolver.py` → `ruff format src/ --check` passes → **unblocks #1448, #1449, and every other open PR**. Merge this first, then #1448 re-runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)