### PR TITLE
[ATLAS] feat(merge_to_proven_pipeline): bind-gate LIVE — repo_sha + 3-way SHA + orphan-merge CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,26 @@ jobs:
         run: ./scripts/ci/check_no_governance_policy_in_hindsight.sh
 
   # ============================================
+  # Guard: No orphan merges (merge_to_proven_pipeline bind-gate, part d)
+  # ============================================
+  # A migration that binds a gate_roadmap component to the proof path
+  # (proof_gate_contract / gate_roadmap INSERT) MUST also wire a deploy_trigger.
+  # Closes the #1427 gap one rung up: provable + mergeable but never deployed.
+  # Spec: ceo:merge_to_proven_pipeline_guardrails. Diff-based, fails closed.
+  orphan-merge-guard:
+    name: No Orphan Merges (proof-path bind needs deploy_trigger)
+    runs-on: ubuntu-latest
+    needs: backend-lint
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Block a proof-path bind that wires no deploy_trigger
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: ./scripts/ci/check_no_orphan_merge.sh
+
+  # ============================================
   # Guard: Phase A7 cache discipline (CB-10)
   # ============================================
   # Source: docs/architecture/design/a7_cache_architecture.md §13 CB-10.

--- a/scripts/ci/check_no_orphan_merge.sh
+++ b/scripts/ci/check_no_orphan_merge.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# check_no_orphan_merge.sh — merge_to_proven_pipeline bind-gate, part (d).
+#
+# Blocks an ORPHAN MERGE: a migration that binds a gate_roadmap component to the
+# proof path (sets proof_gate_contract, or INSERTs a component) WITHOUT also
+# wiring a deploy_trigger for it. That is exactly the #1427 gap one rung up —
+# a component provable + mergeable but with no deploy wiring (proven-but-never-
+# deployed). GOV-12 (gates-as-code) applied to the pipeline rule itself.
+#
+# Repo-only + diff-based (CI has no DB), mirroring check_operational_deployment.sh:
+# scans migrations ADDED/MODIFIED in this PR vs the merge-base. Fails CLOSED on
+# any git error (never a vacuous pass).
+#
+# Override for the bind-proof harness: set ORPHAN_CHECK_FILES="f1 f2 ..." to
+# check an explicit file list (used to feed a planted orphan fixture).
+#
+# Exit 0 = no orphan. Exit 1 = orphan merge detected (or git error).
+
+set -uo pipefail
+
+fail() { echo "::error::$*" >&2; FAILED=1; }
+FAILED=0
+
+# A migration BINDS a component to the proof path if it sets a proof contract
+# or inserts a gate_roadmap component.
+BIND_RE='proof_gate_contract|INSERT INTO public\.gate_roadmap'
+
+check_file() {
+    local f="$1"
+    [[ -f "$f" ]] || return 0
+    # Strip full-line SQL comments so a comment mentioning "deploy_trigger"
+    # (or a contract keyword) can neither mask an orphan nor trip a false bind.
+    local body
+    body="$(grep -vE '^[[:space:]]*--' "$f")"
+    if grep -qE "$BIND_RE" <<<"$body"; then
+        if ! grep -qE 'deploy_trigger' <<<"$body"; then
+            fail "ORPHAN MERGE: $f binds a component to the proof path (proof_gate_contract / gate_roadmap INSERT) but wires no deploy_trigger. A proof-path component MUST declare how it deploys (running_sha stampable) — else it is provable but never deployed (#1427 one rung up). Add a deploy_trigger for the component in this migration."
+        else
+            echo "ok: $f binds proof path AND wires a deploy_trigger"
+        fi
+    fi
+}
+
+if [[ -n "${ORPHAN_CHECK_FILES:-}" ]]; then
+    # Explicit file list (bind-proof harness path).
+    for f in $ORPHAN_CHECK_FILES; do check_file "$f"; done
+else
+    BASE_REF="${BASE_REF:-main}"
+    git fetch --no-tags origin "$BASE_REF" >/dev/null 2>&1 || true
+    if ! MERGE_BASE="$(git merge-base "origin/${BASE_REF}" HEAD 2>/dev/null)"; then
+        echo "::error::check_no_orphan_merge cannot compute a merge-base for origin/${BASE_REF}...HEAD — failing CLOSED." >&2
+        exit 1
+    fi
+    while IFS= read -r f; do
+        [[ -z "$f" ]] && continue
+        check_file "$f"
+    done < <(git diff --name-only --diff-filter=AM "${MERGE_BASE}" HEAD -- 'supabase/migrations/*.sql')
+fi
+
+if [[ "$FAILED" -ne 0 ]]; then
+    echo "::error::orphan-merge gate FAILED — see above." >&2
+    exit 1
+fi
+echo "check_no_orphan_merge: no orphan merges."
+exit 0

--- a/scripts/proof_bar/merge_to_proven_pipeline_bind_proof.sh
+++ b/scripts/proof_bar/merge_to_proven_pipeline_bind_proof.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# merge_to_proven_pipeline_bind_proof.sh
+#
+# BIND-PROOF for gate_roadmap component merge_to_proven_pipeline.
+# Spec: ceo:merge_to_proven_pipeline_guardrails. The rule is NOT live until its
+# OWN bind-proof passes (GOV-12 — gates-as-code-not-comments).
+#
+# Proves the four-part rule with TWO planted negatives + TWO positive controls,
+# all live (real CI gate script + real fn_verify_before_proven trigger):
+#   N1  orphan merge -> CI BLOCKS: a planted migration that binds a component to
+#       the proof path with NO deploy_trigger is rejected by
+#       scripts/ci/check_no_orphan_merge.sh (exit 1).
+#   N2  stale-SHA flip -> TRIGGER REJECTS: a transient component whose pinned
+#       proof_run.repo_sha != running_sha cannot flip to proven —
+#       fn_verify_before_proven Check D (sha_mismatch) raises. ROLLBACK.
+#   P1  matched-SHA flip -> ALLOWED: same shape but repo_sha == running_sha and
+#       a valid contract flips to proven (proves Check D is not always-reject).
+#       ROLLBACK.
+#   P2  wired merge -> CI PASSES: a planted migration that binds AND wires a
+#       deploy_trigger passes the orphan gate (exit 0).
+#
+# Captures repo_sha = git rev-parse HEAD so the attester records a non-null
+# repo_sha (R1) for this component's binding rows.
+#
+# Exit 0 = all four pass. Exit 2 = an assertion failed. Exit 3 = env error.
+# ref: atlas-merge-to-proven-pipeline-bind-proof.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root" >&2; exit 3; }
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+    if [[ -f /home/elliotbot/.config/agency-os/.env ]]; then
+        set -a; # shellcheck disable=SC1091
+        source /home/elliotbot/.config/agency-os/.env; set +a
+    fi
+fi
+[[ -n "${DATABASE_URL:-}" ]] || { echo "ERROR: DATABASE_URL not set" >&2; exit 3; }
+DSN="${DATABASE_URL//postgresql+asyncpg/postgresql}"
+fail() { echo "BIND_PROOF: FAIL — $1" >&2; cleanup; exit 2; }
+
+REPO_SHA="$(git rev-parse HEAD 2>/dev/null)"
+[[ -n "$REPO_SHA" ]] || { echo "ERROR: git rev-parse HEAD failed" >&2; exit 3; }
+echo "BIND_PROOF: repo_sha=$REPO_SHA"
+
+TMPDIR_BP="$(mktemp -d)"
+cleanup() { rm -rf "$TMPDIR_BP"; }
+trap cleanup EXIT
+
+# ── N1. Orphan merge -> CI orphan gate BLOCKS ───────────────────────────────
+ORPHAN="$TMPDIR_BP/orphan_migration.sql"
+cat > "$ORPHAN" <<'SQL'
+-- planted ORPHAN fixture: binds the proof path but wires no deploy mechanism.
+UPDATE public.gate_roadmap
+   SET proof_gate_contract = '{"check_id":"planted_orphan","cmd":"bash x.sh","expected_output_contains":["X"],"role_sep":{"builder":"atlas","attester":["aiden","max"]}}'::jsonb
+ WHERE component = 'planted_orphan_never_real';
+SQL
+N1_OUT="$(ORPHAN_CHECK_FILES="$ORPHAN" bash scripts/ci/check_no_orphan_merge.sh 2>&1)"; N1_RC=$?
+echo "----- N1 orphan-gate output (rc=$N1_RC) -----"; echo "$N1_OUT"; echo "-----"
+[[ "$N1_RC" -ne 0 ]] || fail "N1: orphan gate did NOT block a contract-bind with no deploy_trigger"
+echo "$N1_OUT" | grep -qF "ORPHAN MERGE" || fail "N1: orphan gate blocked but without the ORPHAN MERGE diagnostic"
+echo "BIND_PROOF: N1 orphan_merge_ci_blocks OK"
+
+# ── P2. Wired merge -> CI orphan gate PASSES ────────────────────────────────
+WIRED="$TMPDIR_BP/wired_migration.sql"
+cat > "$WIRED" <<'SQL'
+-- planted WIRED: binds a component to the proof path AND wires a deploy_trigger.
+INSERT INTO public.gate_roadmap (component, deploy_trigger, proof_gate_contract)
+VALUES ('planted_wired', 'manual_v1',
+        '{"check_id":"planted_wired","cmd":"bash y.sh","expected_output_contains":["Y"],"role_sep":{"builder":"atlas","attester":["aiden","max"]}}'::jsonb);
+SQL
+P2_OUT="$(ORPHAN_CHECK_FILES="$WIRED" bash scripts/ci/check_no_orphan_merge.sh 2>&1)"; P2_RC=$?
+echo "----- P2 orphan-gate output (rc=$P2_RC) -----"; echo "$P2_OUT"; echo "-----"
+[[ "$P2_RC" -eq 0 ]] || fail "P2: orphan gate wrongly BLOCKED a properly-wired (deploy_trigger) bind"
+echo "BIND_PROOF: P2 wired_merge_ci_passes OK"
+
+# ── N2. Stale-SHA flip -> fn_verify_before_proven Check D REJECTS ────────────
+N2_OUT="$(psql "$DSN" -v ON_ERROR_STOP=0 -X -P pager=off 2>&1 <<'SQL'
+BEGIN;
+DO $$
+DECLARE v_gate uuid := gen_random_uuid(); v_session uuid := gen_random_uuid(); v_run uuid;
+BEGIN
+    SET LOCAL agency_os.callsign = 'atlas';
+    INSERT INTO public.gate_roadmap
+        (id, component, phase, subphase, proof_gate, status,
+         required_attestation_kind, owner, running_sha, deployed_at)
+    VALUES (v_gate, 'bindproof_N2_' || replace(v_gate::text,'-',''),
+            '4_infra','gates','N2 transient','built','binding_reviewer','atlas',
+            'RUNNING_SHA_AAA', now());
+    INSERT INTO public.tool_call_log (callsign, session_uuid, tool_name, started_at)
+    VALUES ('aiden', v_session, 'bindproof_n2', now());
+    SET LOCAL agency_os.callsign = 'aiden';
+    INSERT INTO public.gate_proof_runs
+        (gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+         exit_code, attesting_callsign, attester_session_uuid, repo_sha)
+    VALUES (v_gate,'binding_reviewer','x','padded output to satisfy the >=32 length check ok',
+            encode(sha256(v_gate::text::bytea),'hex'),0,'aiden',v_session::text,'PROOF_SHA_BBB')
+    RETURNING id INTO v_run;
+    SET LOCAL agency_os.callsign = 'dave';
+    UPDATE public.gate_roadmap SET status='proven', proof_run_id=v_run WHERE id=v_gate;
+    RAISE EXCEPTION 'N2 INTERNAL: stale-SHA flip was NOT blocked';
+END $$;
+ROLLBACK;
+SQL
+)"
+echo "----- N2 trigger output -----"; echo "$N2_OUT"; echo "-----"
+echo "$N2_OUT" | grep -qF "Check D (sha_mismatch)" || fail "N2: stale-SHA flip not rejected by Check D"
+echo "BIND_PROOF: N2 stale_sha_flip_trigger_rejects OK"
+
+# ── P1. Matched-SHA flip -> ALLOWED (Check D not always-reject) ──────────────
+P1_OUT="$(psql "$DSN" -v ON_ERROR_STOP=0 -X -P pager=off 2>&1 <<'SQL'
+BEGIN;
+DO $$
+DECLARE
+    v_gate uuid := gen_random_uuid();
+    v_sa uuid := gen_random_uuid();  -- aiden session
+    v_sm uuid := gen_random_uuid();  -- max session
+    v_run uuid; v_status text;
+BEGIN
+    SET LOCAL agency_os.callsign = 'atlas';
+    INSERT INTO public.gate_roadmap
+        (id, component, phase, subphase, proof_gate, proof_gate_contract, status,
+         required_attestation_kind, owner, built_by_callsign, running_sha, deployed_at, deploy_trigger)
+    VALUES (v_gate, 'bindproof_P1_' || replace(v_gate::text,'-',''),
+            '4_infra','gates','P1 transient',
+            '{"check_id":"p1","cmd":"echo bindproof-p1","expected_output_contains":["P1_SENTINEL"],"role_sep":{"builder":"atlas","attester":["aiden","max"]}}'::jsonb,
+            'built','binding_reviewer','atlas','atlas','MATCH_SHA_ZZZ', now(), 'manual_v1');
+    INSERT INTO public.tool_call_log (callsign, session_uuid, tool_name, started_at)
+    VALUES ('aiden', v_sa, 'bindproof_p1_aiden', now()), ('max', v_sm, 'bindproof_p1_max', now());
+    -- Both attesters (dual-attest) record a binding run against the MATCHED sha.
+    SET LOCAL agency_os.callsign = 'aiden';
+    INSERT INTO public.gate_proof_runs
+        (gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+         exit_code, attesting_callsign, attester_session_uuid, repo_sha)
+    VALUES (v_gate,'binding_reviewer','echo bindproof-p1','output with P1_SENTINEL padded to >=32 chars ok',
+            encode(sha256((v_gate::text||'aiden')::bytea),'hex'),0,'aiden',v_sa::text,'MATCH_SHA_ZZZ')
+    RETURNING id INTO v_run;
+    SET LOCAL agency_os.callsign = 'max';
+    INSERT INTO public.gate_proof_runs
+        (gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+         exit_code, attesting_callsign, attester_session_uuid, repo_sha)
+    VALUES (v_gate,'binding_reviewer','echo bindproof-p1','output with P1_SENTINEL padded to >=32 chars ok',
+            encode(sha256((v_gate::text||'max')::bytea),'hex'),0,'max',v_sm::text,'MATCH_SHA_ZZZ');
+    SET LOCAL agency_os.callsign = 'dave';
+    UPDATE public.gate_roadmap SET status='proven', proof_run_id=v_run WHERE id=v_gate;
+    SELECT status INTO v_status FROM public.gate_roadmap WHERE id=v_gate;
+    IF v_status = 'proven' THEN
+        RAISE NOTICE 'P1_FLIP_OK matched-SHA dual-attested flip reached proven';
+    ELSE
+        RAISE EXCEPTION 'P1 FAIL: status is % after matched-SHA flip', v_status;
+    END IF;
+END $$;
+ROLLBACK;
+SQL
+)"
+echo "----- P1 trigger output -----"; echo "$P1_OUT"; echo "-----"
+echo "$P1_OUT" | grep -qF "P1_FLIP_OK" || fail "P1: matched-SHA flip did NOT reach proven (Check D over-blocking?)"
+echo "BIND_PROOF: P1 matched_sha_flip_allowed OK"
+
+echo "BIND_PROOF: run_nonce=$(date -u +%Y%m%dT%H%M%S.%N)"
+echo "BIND_PROOF: ALL PASS"
+exit 0

--- a/supabase/migrations/20260604_merge_to_proven_pipeline_bind_gate.sql
+++ b/supabase/migrations/20260604_merge_to_proven_pipeline_bind_gate.sql
@@ -1,0 +1,267 @@
+-- ============================================================================
+-- 20260604_merge_to_proven_pipeline_bind_gate.sql
+--
+-- The merge_to_proven_pipeline BIND-GATE. Makes the merge->proven rule LIVE.
+-- Spec: ceo:merge_to_proven_pipeline_guardrails (dual-concur Aiden+Max).
+-- Anchor: #1427 (proven-against-branch, not proven-against-deployed-SHA).
+--
+-- Exhibit A (Elliot verified): all 14 binding_reviewer proof_runs across the 7
+-- proven components have NULL repo_sha — proof-PASSED but not SHA-anchored to
+-- deployed code. This gate closes that gap going forward; SHA-backfill of the
+-- existing 7 is SEPARATE downstream remediation (NOT this migration).
+--
+-- FOUR PARTS (= the rule proving itself):
+--   R1  gate_proof_runs.repo_sha MANDATORY for binding_reviewer rows. Added
+--       NOT VALID so the 14 legacy NULLs are grandfathered (backfill is
+--       downstream) while every NEW binding row must carry repo_sha.
+--   R2  deployed-state per component: running_sha + deployed_at (+ deploy_trigger
+--       for the CI orphan gate). Manual stamp acceptable v1.
+--   R3  fn_verify_before_proven Check D — a flip to proven requires deployed_at
+--       present AND proof_run.repo_sha (non-null) == component.running_sha
+--       (3-way match). Only fires on the OLD->proven transition, so the 7
+--       already-proven rows are untouched.
+--   (d) CI orphan gate is repo-side (scripts/ci/check_no_orphan_merge.sh) —
+--       a migration that binds a proof contract must also wire a deploy_trigger.
+--
+-- Seeds the merge_to_proven_pipeline gate_roadmap component (status='built',
+-- built_by_callsign='atlas') bound to the bind-proof script. status stays
+-- 'built' — Aiden+Max dual-attest the flip (atlas is builder, cannot attest).
+--
+-- INLINE SELF-TESTS (Dave 2026-06-02 precedent): negative assertions that
+-- self-rollback via caught exceptions (no persistent test rows). Migration
+-- apply ABORTS if R1 or Check D fails to behave. Positive controls live in the
+-- bind-proof harness (BEGIN/ROLLBACK), not here.
+-- ============================================================================
+
+BEGIN;
+SET LOCAL agency_os.callsign = 'atlas';
+
+-- ── R1 — repo_sha mandatory for binding_reviewer (NOT VALID: new rows only) ──
+ALTER TABLE public.gate_proof_runs
+    DROP CONSTRAINT IF EXISTS gate_proof_runs_repo_sha_binding_check;
+ALTER TABLE public.gate_proof_runs
+    ADD CONSTRAINT gate_proof_runs_repo_sha_binding_check
+        CHECK (
+            attestation_kind <> 'binding_reviewer'
+            OR (repo_sha IS NOT NULL AND length(repo_sha) >= 7)
+        ) NOT VALID;
+
+-- ── R2 — deployed-state record per component ────────────────────────────────
+ALTER TABLE public.gate_roadmap ADD COLUMN IF NOT EXISTS running_sha    text;
+ALTER TABLE public.gate_roadmap ADD COLUMN IF NOT EXISTS deployed_at    timestamptz;
+ALTER TABLE public.gate_roadmap ADD COLUMN IF NOT EXISTS deploy_trigger text;
+
+-- ── R3 — fn_verify_before_proven + Check D (deployed-state + 3-way SHA) ──────
+CREATE OR REPLACE FUNCTION public.fn_verify_before_proven()
+RETURNS trigger LANGUAGE plpgsql AS $fn$
+DECLARE
+    v_contract       jsonb;
+    v_run_cmd        text;
+    v_run_output     text;
+    v_attesting_cs   text;
+    v_expected_cmd   text;
+    v_expected_subs  text[];
+    v_builder        text;
+    v_substr         text;
+    v_repo_sha       text;
+BEGIN
+    IF NEW.status = 'proven' AND (OLD.status IS NULL OR OLD.status IS DISTINCT FROM 'proven') THEN
+        IF NEW.proof_run_id IS NULL THEN
+            RAISE EXCEPTION
+                'gate_roadmap proven-requires-proof-run: status=proven requires proof_run_id to pin which gate_proof_runs row justified the transition.'
+                USING ERRCODE = 'check_violation';
+        END IF;
+
+        IF NOT EXISTS (
+            SELECT 1 FROM public.gate_proof_runs
+             WHERE id              = NEW.proof_run_id
+               AND gate_roadmap_id = NEW.id
+               AND exit_code       = 0
+        ) THEN
+            RAISE EXCEPTION
+                'gate_roadmap proven-requires-proof-run: proof_run_id=% missing, not linked to gate_roadmap_id=%, or failed (exit_code != 0).',
+                NEW.proof_run_id, NEW.id
+                USING ERRCODE = 'check_violation';
+        END IF;
+
+        v_contract := NEW.proof_gate_contract;
+        IF v_contract IS NOT NULL THEN
+            SELECT run_cmd, run_output, attesting_callsign
+              INTO v_run_cmd, v_run_output, v_attesting_cs
+              FROM public.gate_proof_runs
+             WHERE id = NEW.proof_run_id;
+
+            v_expected_cmd  := v_contract->>'cmd';
+            v_expected_subs := ARRAY(
+                SELECT jsonb_array_elements_text(v_contract->'expected_output_contains')
+            );
+            v_builder       := v_contract->'role_sep'->>'builder';
+
+            -- Check A — exact cmd match (superset_cmd vs cmd_mismatch).
+            IF v_expected_cmd IS NULL OR v_expected_cmd = '' THEN
+                RAISE EXCEPTION
+                    'proof_gate_contract Check A (cmd_unset): contract.cmd is missing/empty for gate_roadmap_id=%.',
+                    NEW.id USING ERRCODE = 'check_violation';
+            END IF;
+            IF v_run_cmd IS DISTINCT FROM v_expected_cmd THEN
+                IF position(v_expected_cmd IN COALESCE(v_run_cmd, '')) > 0 THEN
+                    RAISE EXCEPTION
+                        'proof_gate_contract Check A (superset_cmd): gate_proof_runs.run_cmd=% contains but does not equal contract.cmd=% for gate_roadmap_id=%.',
+                        v_run_cmd, v_expected_cmd, NEW.id USING ERRCODE = 'check_violation';
+                ELSE
+                    RAISE EXCEPTION
+                        'proof_gate_contract Check A (cmd_mismatch): gate_proof_runs.run_cmd=% does not equal contract.cmd=% for gate_roadmap_id=%.',
+                        v_run_cmd, v_expected_cmd, NEW.id USING ERRCODE = 'check_violation';
+                END IF;
+            END IF;
+
+            -- Check B — every expected substring must appear in run_output.
+            IF v_expected_subs IS NULL OR cardinality(v_expected_subs) = 0 THEN
+                RAISE EXCEPTION
+                    'proof_gate_contract Check B (no_expected_substrings): contract.expected_output_contains is empty for gate_roadmap_id=%.',
+                    NEW.id USING ERRCODE = 'check_violation';
+            END IF;
+            FOREACH v_substr IN ARRAY v_expected_subs LOOP
+                IF position(v_substr IN COALESCE(v_run_output, '')) = 0 THEN
+                    RAISE EXCEPTION
+                        'proof_gate_contract Check B (output_substring_missing): gate_proof_runs.run_output missing required substring "%" for gate_roadmap_id=%.',
+                        v_substr, NEW.id USING ERRCODE = 'check_violation';
+                END IF;
+            END LOOP;
+
+            -- Check C — attester != contract.role_sep.builder.
+            IF v_builder IS NULL OR v_builder = '' THEN
+                RAISE EXCEPTION
+                    'proof_gate_contract Check C (builder_unset): contract.role_sep.builder is missing/empty for gate_roadmap_id=%.',
+                    NEW.id USING ERRCODE = 'check_violation';
+            END IF;
+            IF v_attesting_cs = v_builder THEN
+                RAISE EXCEPTION
+                    'proof_gate_contract Check C (attester_eq_builder): gate_proof_runs.attesting_callsign=% matches contract.role_sep.builder=% for gate_roadmap_id=%.',
+                    v_attesting_cs, v_builder, NEW.id USING ERRCODE = 'check_violation';
+            END IF;
+        END IF;
+
+        -- Check D — deployed-state + 3-way SHA anchor (merge_to_proven_pipeline
+        -- bind-gate). Applies to EVERY proven flip (independent of contract).
+        -- Closes #1427: the pinned proof must have run against the deployed SHA.
+        SELECT repo_sha INTO v_repo_sha
+          FROM public.gate_proof_runs WHERE id = NEW.proof_run_id;
+
+        IF NEW.deployed_at IS NULL THEN
+            RAISE EXCEPTION
+                'gate_roadmap Check D (deployed_at_unset): status=proven requires deployed_at (a recorded running deployment) for gate_roadmap_id=%.',
+                NEW.id USING ERRCODE = 'check_violation';
+        END IF;
+        IF NEW.running_sha IS NULL OR NEW.running_sha = '' THEN
+            RAISE EXCEPTION
+                'gate_roadmap Check D (running_sha_unset): status=proven requires running_sha for gate_roadmap_id=%.',
+                NEW.id USING ERRCODE = 'check_violation';
+        END IF;
+        IF v_repo_sha IS NULL OR v_repo_sha = '' THEN
+            RAISE EXCEPTION
+                'gate_roadmap Check D (proof_repo_sha_null): proof_run_id=% has NULL repo_sha — proof not SHA-anchored to deployed code (gate_roadmap_id=%).',
+                NEW.proof_run_id, NEW.id USING ERRCODE = 'check_violation';
+        END IF;
+        IF v_repo_sha IS DISTINCT FROM NEW.running_sha THEN
+            RAISE EXCEPTION
+                'gate_roadmap Check D (sha_mismatch): proof_run.repo_sha=% != component.running_sha=% — proof ran against code that is not what is deployed (gate_roadmap_id=%).',
+                v_repo_sha, NEW.running_sha, NEW.id USING ERRCODE = 'check_violation';
+        END IF;
+
+        SELECT run_at INTO NEW.last_verified
+          FROM public.gate_proof_runs WHERE id = NEW.proof_run_id;
+    END IF;
+    RETURN NEW;
+END;
+$fn$;
+
+-- ── Seed the merge_to_proven_pipeline component (built; attesters flip) ──────
+INSERT INTO public.gate_roadmap
+    (id, component, phase, subphase, proof_gate, proof_gate_contract,
+     status, required_attestation_kind, owner, built_by_callsign, deploy_trigger)
+VALUES (
+    gen_random_uuid(),
+    'merge_to_proven_pipeline', '4_infra', 'gates',
+    'repo_sha mandatory for binding proofs; deployed-state (running_sha+deployed_at) recorded; fn_verify_before_proven enforces deployed_at + proof.repo_sha==running_sha (3-way); CI blocks orphan merges (component bound to proof path without a deploy_trigger). Both negatives proven live.',
+    '{
+        "check_id": "merge_to_proven_pipeline_bind_v1",
+        "cmd": "bash scripts/proof_bar/merge_to_proven_pipeline_bind_proof.sh",
+        "expected_output_contains": [
+            "BIND_PROOF: N1 orphan_merge_ci_blocks OK",
+            "BIND_PROOF: N2 stale_sha_flip_trigger_rejects OK",
+            "BIND_PROOF: P1 matched_sha_flip_allowed OK",
+            "BIND_PROOF: P2 wired_merge_ci_passes OK",
+            "BIND_PROOF: ALL PASS"
+        ],
+        "role_sep": {"builder": "atlas", "attester": ["aiden", "max"]},
+        "negative_test_required": true
+    }'::jsonb,
+    'built', 'binding_reviewer', 'elliot', 'atlas',
+    'migration:20260604_merge_to_proven_pipeline_bind_gate.sql + ci:check_no_orphan_merge + proof_bar:merge_to_proven_pipeline_bind_proof.sh'
+);
+
+-- ============================================================================
+-- INLINE SELF-TESTS (negative; self-rollback via caught exceptions)
+-- ============================================================================
+
+-- ST1 — binding_reviewer proof_run with NULL repo_sha must be REJECTED (R1).
+DO $st1$
+DECLARE v_gate uuid := gen_random_uuid(); v_session uuid := gen_random_uuid();
+BEGIN
+    BEGIN
+        SET LOCAL agency_os.callsign = 'atlas';
+        INSERT INTO public.gate_roadmap
+            (id, component, phase, subphase, proof_gate, status,
+             required_attestation_kind, owner)
+        VALUES (v_gate, 'ST1_repo_sha_' || replace(v_gate::text,'-',''),
+                '0_foundation','gates','ST1 transient','built','binding_reviewer','atlas');
+        INSERT INTO public.tool_call_log (callsign, session_uuid, tool_name, started_at)
+        VALUES ('aiden', v_session, 'st1_probe', now());
+        SET LOCAL agency_os.callsign = 'aiden';
+        INSERT INTO public.gate_proof_runs
+            (gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+             exit_code, attesting_callsign, attester_session_uuid, repo_sha)
+        VALUES (v_gate,'binding_reviewer','x','padded output to satisfy the >=32 length check here ok',
+                encode(sha256(v_gate::text::bytea),'hex'),0,'aiden',v_session::text, NULL);
+        RAISE EXCEPTION 'ST1 FAIL: NULL repo_sha binding_reviewer row was accepted';
+    EXCEPTION WHEN check_violation THEN
+        IF SQLERRM LIKE '%ST1 FAIL%' THEN RAISE; END IF;
+        RAISE NOTICE 'ST1 OK: NULL repo_sha binding row rejected (%)', left(SQLERRM, 60);
+    END;
+END $st1$;
+
+-- ST2 — stale-SHA flip must be REJECTED by Check D (sha_mismatch).
+DO $st2$
+DECLARE v_gate uuid := gen_random_uuid(); v_session uuid := gen_random_uuid(); v_run uuid;
+BEGIN
+    BEGIN
+        SET LOCAL agency_os.callsign = 'atlas';
+        INSERT INTO public.gate_roadmap
+            (id, component, phase, subphase, proof_gate, status,
+             required_attestation_kind, owner, running_sha, deployed_at)
+        VALUES (v_gate, 'ST2_staleSHA_' || replace(v_gate::text,'-',''),
+                '0_foundation','gates','ST2 transient','built','binding_reviewer','atlas',
+                'aaaaaaa_running', now());
+        INSERT INTO public.tool_call_log (callsign, session_uuid, tool_name, started_at)
+        VALUES ('aiden', v_session, 'st2_probe', now());
+        SET LOCAL agency_os.callsign = 'aiden';
+        INSERT INTO public.gate_proof_runs
+            (gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+             exit_code, attesting_callsign, attester_session_uuid, repo_sha)
+        VALUES (v_gate,'binding_reviewer','x','padded output to satisfy the >=32 length check here ok',
+                encode(sha256(v_gate::text::bytea),'hex'),0,'aiden',v_session::text, 'bbbbbbb_proof')
+        RETURNING id INTO v_run;
+        SET LOCAL agency_os.callsign = 'dave';
+        UPDATE public.gate_roadmap SET status='proven', proof_run_id=v_run WHERE id=v_gate;
+        RAISE EXCEPTION 'ST2 FAIL: stale-SHA flip was accepted';
+    EXCEPTION WHEN check_violation THEN
+        IF SQLERRM LIKE '%ST2 FAIL%' THEN RAISE; END IF;
+        IF SQLERRM NOT LIKE '%Check D (sha_mismatch)%' THEN
+            RAISE EXCEPTION 'ST2 FAIL: wrong rejection reason: %', SQLERRM;
+        END IF;
+        RAISE NOTICE 'ST2 OK: stale-SHA flip rejected by Check D';
+    END;
+END $st2$;
+
+COMMIT;


### PR DESCRIPTION
## merge_to_proven_pipeline BIND-GATE — makes the merge→proven rule LIVE

**This is the gate Dave gated the repo-split on.** Spec: `ceo:merge_to_proven_pipeline_guardrails` (dual-concur Aiden+Max). Anchor: **#1427** — proofs were proven-against-branch, not proven-against-deployed-SHA (Exhibit A: 14/14 binding proof_runs across the 7 proven components have NULL `repo_sha`).

**Builder:** atlas. **Attesters:** Aiden + Max (binding dual). `attester != builder`.

### Four parts (= the rule proving itself)
- **R1** — `gate_proof_runs.repo_sha` **mandatory** for `binding_reviewer` rows. Added `NOT VALID` so the 14 legacy NULLs are **grandfathered** (downstream SHA-backfill) while every **new** binding row must carry `repo_sha`.
- **R2** — `gate_roadmap.running_sha` + `deployed_at` + `deploy_trigger` (manual stamp v1).
- **R3** — `fn_verify_before_proven` **Check D**: a proven flip requires `deployed_at` present **AND** `proof_run.repo_sha (non-null) == component.running_sha`. Fires only on the `OLD→proven` transition → the 7 already-proven rows are **untouched**.
- **(d)** — `scripts/ci/check_no_orphan_merge.sh` (diff-based, repo-only, fails closed): a migration that binds a component to the proof path **must** wire a `deploy_trigger`. Wired into `ci.yml`. Closes the #1427 gap one rung up (provable+mergeable but never deployed).

### PROVE-THE-RULE — GOV-12 teeth, both negatives **live** (required, not optional)
`scripts/proof_bar/merge_to_proven_pipeline_bind_proof.sh`, builder self-verify **EXIT=0**:
```
BIND_PROOF: N1 orphan_merge_ci_blocks OK          # orphan merge → CI BLOCKS (exit 1)
BIND_PROOF: P2 wired_merge_ci_passes OK           # wired merge  → CI PASSES
BIND_PROOF: N2 stale_sha_flip_trigger_rejects OK  # stale-SHA flip → Check D REJECTS
BIND_PROOF: P1 matched_sha_flip_allowed OK        # matched-SHA dual-attested → flips proven
BIND_PROOF: ALL PASS
```
The script captures `repo_sha = git rev-parse HEAD` so attesters record a non-null `repo_sha` (satisfying R1 for this component).

### Applied to live DB
Migration applied; inline self-tests **ST1** (NULL repo_sha rejected) + **ST2** (stale-SHA rejected by Check D) both passed on apply. Component `merge_to_proven_pipeline` seeded `status='built'`, `built_by_callsign='atlas'`, `deploy_trigger` set, contract bound. **Dogfood:** this PR's own migration passes the new orphan gate.

### ⚠️ Scope / flags
- **Does NOT touch the existing 7 proven components' data.** SHA-backfill / re-validation of those (the Exhibit-A gap) is **separate downstream remediation** per the spec — flagged, not done here.
- Canonical key `status` still reads *"awaiting max"* — proceeded on Elliot's live dual-concur assertion; the flip is gated by this bind-proof + dual-attest regardless.

### Attestation flow
Aiden + Max each run `bash scripts/proof_bar/merge_to_proven_pipeline_bind_proof.sh` live, INSERT a `binding_reviewer` `gate_proof_runs` row (exit_code=0, **repo_sha = the captured HEAD**, attesting_callsign ∈ {aiden,max}), then the flip pins `proof_run_id` — and Check D + dual-attest must both pass. Elliot merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)