### PR TITLE
[ATLAS] fix(ci): ruff format kv_resolver.py — unblock whole-tree lint (red-walls all open PRs)

### DIFF
--- a/src/keiracom_system/vault/kv_resolver.py
+++ b/src/keiracom_system/vault/kv_resolver.py
@@ -122,8 +122,8 @@ SECRET_MANIFEST: tuple[tuple[str, str, str], ...] = (
 # env var by resolve_into_env after the manifest pass.
 #   alias_env_var -> canonical_env_var
 SECRET_ALIASES: dict[str, str] = {
-    "SUPABASE_DB_DSN": "DATABASE_URL",   # env: "copied from DATABASE_URL"
-    "OPENAI_APIKEY": "OPENAI_API_KEY",   # typo-variant; flagged for code cleanup
+    "SUPABASE_DB_DSN": "DATABASE_URL",  # env: "copied from DATABASE_URL"
+    "OPENAI_APIKEY": "OPENAI_API_KEY",  # typo-variant; flagged for code cleanup
 }
 
 


### PR DESCRIPTION
## Shared-CI unblock — format-only

`Backend Lint (Ruff)` runs **whole-tree** (`ruff format src/ --check`). One file is unformatted on `main` — `src/keiracom_system/vault/kv_resolver.py` (trivial inline-comment double→single space) — so it **fails every open PR** (1444, 1448, 1451 all consistent tonight).

- **Provenance:** introduced by #1443 (NOVA, vault_secrets Phase 1) — not from any of the failing PRs.
- **Change:** `ruff format` only, 2 lines, **no logic change**. `ruff check` + `ruff format --check` both clean whole-tree after.

Land this on main → the three failing PRs rebase to green. (Root pattern: `ci.yml` installs unpinned `ruff` — a version bump can newly-flag previously-clean files; pinning ruff is a worthwhile follow-up, out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)