### PR TITLE
[ATLAS] fix(migration): make bind-gate migration idempotent (rebuild-safe)

### DIFF
--- a/supabase/migrations/20260604_merge_to_proven_pipeline_bind_gate.sql
+++ b/supabase/migrations/20260604_merge_to_proven_pipeline_bind_gate.sql
@@ -177,10 +177,13 @@ END;
 $fn$;
 
 -- ── Seed the merge_to_proven_pipeline component (built; attesters flip) ──────
+-- Idempotent: skip if the component already exists (re-apply over already-
+-- present prod, or a fresh-DB rebuild from migration history). Never seeds a
+-- duplicate; never resets an already-proven row back to 'built'.
 INSERT INTO public.gate_roadmap
     (id, component, phase, subphase, proof_gate, proof_gate_contract,
      status, required_attestation_kind, owner, built_by_callsign, deploy_trigger)
-VALUES (
+SELECT
     gen_random_uuid(),
     'merge_to_proven_pipeline', '4_infra', 'gates',
     'repo_sha mandatory for binding proofs; deployed-state (running_sha+deployed_at) recorded; fn_verify_before_proven enforces deployed_at + proof.repo_sha==running_sha (3-way); CI blocks orphan merges (component bound to proof path without a deploy_trigger). Both negatives proven live.',
@@ -199,6 +202,8 @@ VALUES (
     }'::jsonb,
     'built', 'binding_reviewer', 'elliot', 'atlas',
     'migration:20260604_merge_to_proven_pipeline_bind_gate.sql + ci:check_no_orphan_merge + proof_bar:merge_to_proven_pipeline_bind_proof.sh'
+WHERE NOT EXISTS (
+    SELECT 1 FROM public.gate_roadmap WHERE component = 'merge_to_proven_pipeline'
 );
 
 -- ============================================================================


### PR DESCRIPTION
## Make the bind-gate migration idempotent (close the migration-tracking gap's prerequisite)

**Catch (Head of Ops, Elliot-verified):** `20260604_merge_to_proven_pipeline_bind_gate` was applied **directly via psql**, so it is **not in `supabase_migrations.schema_migrations`**. A fresh-DB rebuild from migration history would re-run it — and the original component-seed `INSERT` was not re-appliable (would duplicate / can't re-run over the existing proven row).

### Fix (step 1 of the dispatch — idempotency)
Guard the component seed with `INSERT ... SELECT ... WHERE NOT EXISTS`. Now re-applying over already-present prod **or** a fresh rebuild is safe: never duplicates, never resets an already-`proven` row to `built`. Every other statement was already re-appliable (`CREATE OR REPLACE`, `DROP IF EXISTS + ADD ... NOT VALID`, `ADD COLUMN IF NOT EXISTS`, self-rollback ST1/ST2).

**Verified:**
- Re-applied over current prod → `INSERT 0 0` (skipped), `ST1 OK` + `ST2 OK` re-pass, component stays **1 row / proven**.
- `merge_to_proven_pipeline_bind_proof.sh` re-passes **EXIT=0** (N1/N2/P1/P2 all hold).

### ⚠️ Surfaced: the tracking gap is **systemic**, not my-migration-specific
- `created_by` on every tracked `schema_migrations` row = **Dave's Supabase account** — the agent `psql DATABASE_URL` path can't write `schema_migrations`.
- **None** of the recent sibling migrations are tracked (watchdog_reaper, vault_backend_live, weaviate_offsite, three_store_sync_proof, …).
- **~81 of 202** migration files are untracked. `supabase migration up` would treat all 81 as pending and re-apply against prod — most aren't idempotent → mass-conflict blast radius. **Not a safe unilateral run.**

This PR makes the bind-gate file **ready** for whatever canonical (Dave-auth) tracked-apply path lands it into `schema_migrations`. The broader 81-file drift is flagged as a separate governance item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)