### PR TITLE
[NOVA] vault-envwrap launcher BUILD (#1448 design → code) — gates the attended cutover

### DIFF
--- a/scripts/install_vault_envwrap_shim.sh
+++ b/scripts/install_vault_envwrap_shim.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# install_vault_envwrap_shim.sh — install the stable ~/.local/bin/vault-envwrap
+# shim that fronts the in-repo launcher (split-resilient: units reference the
+# shim by a host path + ${AGENCY_OS_REPO}, never the repo tree directly).
+#
+# Idempotent. Host-side infra (admin-bypass acceptable per orchestrator-merge
+# scope) — the launcher itself (scripts/vault_envwrap.py) is the reviewed repo code.
+set -euo pipefail
+
+BIN="$HOME/.local/bin"
+SHIM="$BIN/vault-envwrap"
+mkdir -p "$BIN"
+
+cat > "$SHIM" <<'EOF'
+#!/usr/bin/env bash
+# vault-envwrap shim → in-repo launcher. Repo location via ${AGENCY_OS_REPO}
+# (split-resilient: the repo-split re-points this one value, all units follow).
+set -u
+AGENCY_OS_REPO="${AGENCY_OS_REPO:-/home/elliotbot/clawd/Agency_OS}"
+PY="$AGENCY_OS_REPO/.venv/bin/python3"
+[[ -x "$PY" ]] || PY="$(command -v python3)"
+exec "$PY" "$AGENCY_OS_REPO/scripts/vault_envwrap.py" "$@"
+EOF
+
+chmod +x "$SHIM"
+echo "installed: $SHIM"
+"$SHIM" --verify >/dev/null 2>&1 && echo "shim --verify: OK" || echo "shim --verify: (check VAULT env)"

--- a/scripts/proof_bar/vault_envwrap_live.sh
+++ b/scripts/proof_bar/vault_envwrap_live.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# vault_envwrap_live.sh
+#
+# LIVE proof for the vault-envwrap launcher (vault_secrets Phase 2): a process
+# launched through the launcher resolves its secrets FROM VAULT — proven by
+# running with NO .env (env -i, only VAULT_ADDR/VAULT_TOKEN) so the only possible
+# source is Vault. Bound as proof_gate_contract.cmd (contract.cmd=bash → a pytest
+# run_cmd fails Check A).
+#
+# Required run_output substrings (Check B):
+#   VAULT_RESOLVE_NO_ENV_OK        (--verify resolves >0 secrets with no .env)
+#   WRAPPED_CMD_SAW_VAULT_SECRET=true  (exec'd cmd inherits a Vault-resolved secret)
+#   VAULT_ENVWRAP_PROOF_OK
+#
+# Exit 0 on a verified Vault-sourced launch; 2 on assertion failure; 3 env error.
+#
+# ref: NOVA vault-envwrap launcher (#1448 design) built->proven.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LAUNCHER="$REPO_ROOT/scripts/vault_envwrap.py"
+
+if [[ -z "${VAULT_ADDR:-}" || -z "${VAULT_TOKEN:-}" ]]; then
+    if [[ -f /home/elliotbot/.config/agency-os/.env ]]; then
+        # shellcheck disable=SC1091
+        source /home/elliotbot/.config/agency-os/.env
+    fi
+fi
+if [[ -z "${VAULT_ADDR:-}" || -z "${VAULT_TOKEN:-}" ]]; then
+    echo "ERROR: VAULT_ADDR/VAULT_TOKEN not set" >&2
+    exit 3
+fi
+
+# 1. --verify with NO .env inheritance: the only secret source is Vault.
+VOUT="$(env -i VAULT_ADDR="$VAULT_ADDR" VAULT_TOKEN="$VAULT_TOKEN" PATH="$PATH" \
+    python3 "$LAUNCHER" --verify 2>&1)"
+echo "$VOUT"
+if echo "$VOUT" | grep -Eq "VERIFY OK — [1-9][0-9]* secrets resolved from Vault"; then
+    echo "VAULT_RESOLVE_NO_ENV_OK"
+else
+    echo "MISSING: VAULT_RESOLVE_NO_ENV_OK" >&2
+    exit 2
+fi
+
+# 2. exec mode with NO .env: the wrapped command must inherit a Vault-resolved secret.
+WOUT="$(env -i VAULT_ADDR="$VAULT_ADDR" VAULT_TOKEN="$VAULT_TOKEN" PATH="$PATH" \
+    python3 "$LAUNCHER" -- bash -c 'echo SAW=${ANTHROPIC_API_KEY:+true}' 2>&1)"
+echo "$WOUT"
+if echo "$WOUT" | grep -Fq "SAW=true"; then
+    echo "WRAPPED_CMD_SAW_VAULT_SECRET=true"
+else
+    echo "MISSING: WRAPPED_CMD_SAW_VAULT_SECRET=true" >&2
+    exit 2
+fi
+
+echo "VAULT_ENVWRAP_PROOF_OK"
+exit 0

--- a/scripts/vault_envwrap.py
+++ b/scripts/vault_envwrap.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""vault_envwrap.py — Vault-resolved service launcher (vault_secrets Phase 2).
+
+Systemd ExecStart wrapper: resolves every fleet secret from Vault into os.environ
+(via kv_resolver.resolve_into_env), then exec's the wrapped service command so it
+inherits the Vault-populated environment. Generalises the proven agent-spawn
+cold-start (#1289) to host services.
+
+GRACEFUL-FALLBACK mode (Dave/Elliot ratified for the staggered rollout): the unit
+KEEPS `EnvironmentFile=.env` during cutover, so if Vault is unreachable/sealed the
+inherited .env values remain and the service still boots. The launcher logs whether
+it resolved from Vault or fell back — failure is visible, never silent, never an
+outage. Plaintext .env is the rollback net until ALL units are proven; only then
+does it become fail-closed + the carve-outs get pruned.
+
+Split-resilient (design #1448 §11): self-locates its repo root from __file__, so the
+kv_resolver import works wherever the repo lives after the repo-split.
+
+Usage (systemd):
+  ExecStart=%h/.local/bin/vault-envwrap -- /path/python /path/script.py
+Modes:
+  --verify   resolve + report, do NOT exec (dry-run; exit 0 if VAULT reachable)
+  default    resolve (graceful), then exec the command after `--`
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]  # scripts/ -> repo root (split-resilient)
+sys.path.insert(0, str(REPO))
+
+logging.basicConfig(level=logging.INFO, format="vault-envwrap: %(message)s", stream=sys.stderr)
+logger = logging.getLogger("vault_envwrap")
+
+
+def _resolve() -> tuple[int, int]:
+    """Resolve secrets from Vault into os.environ. Returns (resolved, missing).
+    Graceful: any failure logs and returns (0, -1) — caller still exec's with the
+    inherited (.env) environment as the rollback net."""
+    from src.keiracom_system.vault.kv_resolver import resolve_into_env
+
+    try:
+        result = resolve_into_env()
+    except Exception as exc:  # noqa: BLE001 — graceful fallback to inherited .env
+        logger.warning("Vault resolve FAILED (%s) — falling back to inherited env", exc)
+        return 0, -1
+    logger.info(
+        "resolved %d secrets from Vault (%d missing, %d errors)",
+        len(result.resolved),
+        len(result.missing),
+        len(result.errors),
+    )
+    return len(result.resolved), len(result.missing)
+
+
+def main(argv: list[str]) -> int:
+    args = argv[1:]
+    verify = False
+    if args and args[0] == "--verify":
+        verify = True
+        args = args[1:]
+    if args and args[0] == "--":
+        args = args[1:]
+
+    resolved, _ = _resolve()
+
+    if verify:
+        if resolved > 0:
+            logger.info("VERIFY OK — %d secrets resolved from Vault", resolved)
+            return 0
+        logger.error("VERIFY FAILED — 0 secrets resolved from Vault")
+        return 1
+
+    if not args:
+        logger.error("no command to exec after `--`")
+        return 2
+
+    # Replace the process image so the service inherits the resolved environment.
+    os.execvp(args[0], args)
+    return 127  # unreachable unless execvp fails
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_vault_envwrap.py
+++ b/tests/test_vault_envwrap.py
@@ -1,0 +1,63 @@
+"""Unit tests for scripts/vault_envwrap.py — the Vault-resolved service launcher.
+
+Fast units (mock resolve). The live Vault proof is scripts/proof_bar/vault_envwrap_live.sh.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+vw = importlib.import_module("scripts.vault_envwrap")
+
+
+class _Result:
+    def __init__(self, n):
+        self.resolved = {f"K{i}": "v" for i in range(n)}
+        self.missing = []
+        self.errors = {}
+
+
+def _patch_resolve(monkeypatch, n=None, raises=False):
+    import src.keiracom_system.vault.kv_resolver as kv
+
+    def fake():
+        if raises:
+            raise RuntimeError("vault down")
+        return _Result(n)
+
+    monkeypatch.setattr(kv, "resolve_into_env", fake)
+
+
+def test_verify_ok_when_secrets_resolve(monkeypatch, capsys):
+    _patch_resolve(monkeypatch, n=5)
+    rc = vw.main(["vault_envwrap.py", "--verify"])
+    assert rc == 0
+
+
+def test_verify_fails_when_zero_resolved(monkeypatch):
+    _patch_resolve(monkeypatch, n=0)
+    rc = vw.main(["vault_envwrap.py", "--verify"])
+    assert rc == 1
+
+
+def test_graceful_fallback_on_vault_failure(monkeypatch):
+    """Vault unreachable → resolve returns (0,-1), --verify reports failure but
+    does NOT raise (graceful — exec path would fall back to inherited .env)."""
+    _patch_resolve(monkeypatch, raises=True)
+    rc = vw.main(["vault_envwrap.py", "--verify"])
+    assert rc == 1  # verify flags it, but no exception bubbled
+
+
+def test_no_command_after_separator_returns_2(monkeypatch):
+    _patch_resolve(monkeypatch, n=3)
+    assert vw.main(["vault_envwrap.py", "--"]) == 2
+
+
+def test_exec_replaces_process(monkeypatch):
+    """Default mode resolves then execvp's the command after `--`."""
+    _patch_resolve(monkeypatch, n=3)
+    called = {}
+    monkeypatch.setattr(vw.os, "execvp", lambda f, a: called.update(file=f, argv=a))
+    vw.main(["vault_envwrap.py", "--", "/bin/echo", "hi"])
+    assert called["file"] == "/bin/echo"
+    assert called["argv"] == ["/bin/echo", "hi"]


### PR DESCRIPTION
## Executing the approved #1448 design — the launcher code

**ATTENDED build window** (Dave + Head of Ops live). This is the code the staggered cutover needs; **no unit can be cut until this is merged + deployed to the main worktree** (`/home/elliotbot/clawd/Agency_OS`) — that's the path the 80 units run from.

### Files
- `scripts/vault_envwrap.py` — `resolve_into_env()` (Vault → `os.environ`) then `execvp` the wrapped service. **Graceful-fallback**: Vault-down logs + falls back to inherited `.env` (the rollback net) — never silent, never an outage. `--verify` dry-run. Split-resilient (self-locates via `__file__`).
- `scripts/install_vault_envwrap_shim.sh` — installs `~/.local/bin/vault-envwrap` (`${AGENCY_OS_REPO}`-relative).
- `scripts/proof_bar/vault_envwrap_live.sh` — LIVE proof.
- `tests/test_vault_envwrap.py` — 5 units (pass).

### Live proof (verbatim) — resolves from Vault with `.env` ABSENT
```
VAULT_RESOLVE_NO_ENV_OK
WRAPPED_CMD_SAW_VAULT_SECRET=true
VAULT_ENVWRAP_PROOF_OK   (exit 0; 71 secrets resolved from Vault, env -i, no .env)
```

### Cutover sequence (post-merge+deploy)
1. Merge this → pull main worktree → `bash scripts/install_vault_envwrap_shim.sh`.
2. **Pilot** `agency-os-alert-budget-threshold` (oneshot, low-risk): systemd drop-in → `ExecStart` via `vault-envwrap`, **keep `EnvironmentFile=.env`**, add `After=/Requires=keiracom-vault-unseal.service`. `daemon-reload` + run → verify green + journal shows "resolved N from Vault".
3. ONE-AT-A-TIME across the 80, verify-green per unit, **HALT + #ceo on any failure**, progress per 5–10.
4. `.env` carve-outs pruned only after ALL proven; then fail-closed flip.

### Proof gate (merge→deploy→prove)
Component proven when: launcher at `repo_sha == running_sha`, all 80 units on `vault-envwrap`, none on plaintext, dual NON-BUILDER attest (Aiden+Max).

🤖 Generated with [Claude Code](https://claude.com/claude-code)