### PR TITLE
[ATLAS] fix(proof_bar): repo_sha on negative-probe binding rows (R1 regression)

### DIFF
--- a/scripts/proof_bar/_live_rejection_probe.sql
+++ b/scripts/proof_bar/_live_rejection_probe.sql
@@ -43,7 +43,7 @@ BEGIN
     SET LOCAL agency_os.callsign = 'aiden';
     INSERT INTO public.gate_proof_runs (
         gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
-        exit_code, attesting_callsign, attester_session_uuid
+        exit_code, attesting_callsign, attester_session_uuid, repo_sha
     ) VALUES (
         v_gate_id,
         'binding_reviewer',
@@ -52,7 +52,11 @@ BEGIN
         encode(sha256(v_gate_id::text::bytea), 'hex'),
         0,
         'aiden',
-        v_session_uuid::text
+        v_session_uuid::text,
+        -- repo_sha placeholder: required by the binding-row constraint (R1,
+        -- merge_to_proven bind-gate). Irrelevant here — this probe tests
+        -- Check A (cmd_mismatch), which raises before repo_sha is read.
+        'liverej_repo_sha_unused_for_check_a'
     ) RETURNING id INTO v_run_id;
 
     SET LOCAL agency_os.callsign = 'dave';

--- a/scripts/proof_bar/litellm_routing_live_proof.sh
+++ b/scripts/proof_bar/litellm_routing_live_proof.sh
@@ -214,13 +214,16 @@ BEGIN
     SET LOCAL agency_os.callsign = 'aiden';
     INSERT INTO public.gate_proof_runs
         (gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
-         exit_code, attesting_callsign, attester_session_uuid)
+         exit_code, attesting_callsign, attester_session_uuid, repo_sha)
     VALUES (
         v_gate, 'binding_reviewer',
         'pytest tests/retrieval/test_hyde.py -v',
         'mock pytest output — padded to satisfy the >=32 char run_output check here',
         encode(sha256(v_gate::text::bytea), 'hex'),
-        0, 'aiden', v_session::text)
+        -- repo_sha placeholder: required by the binding-row constraint (R1,
+        -- merge_to_proven bind-gate). Irrelevant to this probe, which tests
+        -- Check A (cmd_mismatch) — Check A raises before Check D ever reads it.
+        0, 'aiden', v_session::text, 'c5probe_repo_sha_unused_for_check_a')
     RETURNING id INTO v_run;
     SET LOCAL agency_os.callsign = 'dave';
     UPDATE public.gate_roadmap SET status = 'proven', proof_run_id = v_run WHERE id = v_gate;


### PR DESCRIPTION
## Fix: R1 bind-gate constraint regressed two proof-bar negative probes

The `merge_to_proven` bind-gate **R1** constraint (`gate_proof_runs_repo_sha_binding_check`: `binding_reviewer` rows require non-null `repo_sha`) silently broke two existing proof scripts whose transient negative-probe inserts a `binding_reviewer` row with **NULL repo_sha**:
- `litellm_routing_live_proof.sh` (C5 GOV-12 teeth) — **was blocking litellm re-validation**
- `_live_rejection_probe.sql` → used by `product_proof_enforcement_live_rejection.sh`

Both probes test `trg_01` **Check A (cmd_mismatch)**, which raises *before* `repo_sha` is read — but R1 rejects the INSERT first, so the probe never reaches its assertion and the proof exits 2. Caught by the litellm re-run pre-check at the deployed SHA (`new row … violates check constraint gate_proof_runs_repo_sha_binding_check`).

**Fix:** add a placeholder `repo_sha` to each transient INSERT. Value is irrelevant to a Check-A probe and the rows are `ROLLBACK`-only. **Behavior-preserving** — same `expected_output_contains` tokens, same EXIT 0.

**Verified against prod (R1 live):**
- `litellm_routing_live_proof.sh` → EXIT 0 (C5 OK + ALL PASS)
- `product_proof_enforcement_live_rejection.sh` → EXIT 0

Anchor: my own bind-gate change; GOV-10 resolve-now. No other proof scripts affected (`merge_to_proven_pipeline_bind_proof.sh` already sets repo_sha; the rest don't insert binding rows in their probes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)