### PR TITLE
[SCOUT] feat(proof_gate): product_gtm readiness proof + contract + built_by=scout

### DIFF
--- a/scripts/proof_bar/product_gtm_proof.sh
+++ b/scripts/proof_bar/product_gtm_proof.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# product_gtm_proof.sh
+#
+# Proof for gate_roadmap component product_gtm
+# (id = f3f42557-40f5-4602-8239-ca09fa1da9e3, phase 6_product).
+#
+# proof_gate prose: "1-pager + launch comms approved and ready".
+#
+# product_gtm is a DOCS/ARTIFACT-readiness gate, not a runtime service. This
+# proof asserts the READY half — the launch kit artifact exists at the deployed
+# (committed) repo_sha and contains the complete 1-pager + launch-comms
+# structure. The APPROVED half is the Aiden+Max dual-attest itself (a human
+# governance signal a script cannot assert). Interpretation surfaced to Elliot
+# before the PR — same shape as the three_store_sync scope note.
+#
+# Bound as proof_gate_contract.cmd; trg_01 Check A pins run_cmd to EXACTLY:
+#     bash scripts/proof_bar/product_gtm_proof.sh
+# so a pytest/mock run_cmd fails Check A (cmd_mismatch) — the structural
+# negative bar.
+#
+# Emits each PRODUCT_GTM_PROOF token only after its assertion passes.
+# Exit 0 = ready. Exit 2 = a required section/artifact missing. Exit 3 = env error.
+# ref: scout-product-gtm-proof.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || { echo "ERROR: cannot cd to repo root" >&2; exit 3; }
+
+KIT="docs/launch/KEI-131_gtm_launch_kit.md"
+fail() { echo "PRODUCT_GTM_PROOF: FAIL — $1" >&2; exit "${2:-2}"; }
+
+[[ -f "$KIT" ]] || fail "launch kit artifact missing: $KIT" 2
+[[ -s "$KIT" ]] || fail "launch kit artifact is empty: $KIT" 2
+
+# ── 1. The 1-pager (positioning doc) with its load-bearing subsections ───────
+grep -qF "## §1 — One-Pager (positioning doc)" "$KIT" || fail "§1 One-Pager section missing"
+grep -qF "### Pricing"                          "$KIT" || fail "§1 Pricing subsection missing"
+grep -qF "### Call-to-action"                   "$KIT" || fail "§1 Call-to-action subsection missing"
+echo "PRODUCT_GTM_PROOF: one-pager complete OK"
+
+# ── 2. Launch comms — email template + social posts ──────────────────────────
+grep -qF "## §2 — Launch Email Template" "$KIT" || fail "§2 Launch Email Template missing"
+grep -qF "## §3 — Social Launch Posts"   "$KIT" || fail "§3 Social Launch Posts missing"
+echo "PRODUCT_GTM_PROOF: launch-comms complete OK"
+
+# ── 3. repo_sha against deployed (committed) code ────────────────────────────
+REPO_SHA="$(git rev-parse HEAD 2>/dev/null)"
+[[ -n "$REPO_SHA" ]] || fail "could not resolve repo_sha" 3
+# Confirm the artifact is committed at this sha (deployed, not a dirty work-tree).
+git cat-file -e "HEAD:$KIT" 2>/dev/null || fail "launch kit not committed at HEAD ($KIT)" 2
+echo "PRODUCT_GTM_PROOF: artifact committed repo_sha=$REPO_SHA OK"
+
+# ── uniqueness line (distinct run_output → distinct output_sha256, so the
+#    UNIQUE(gate_roadmap_id, output_sha256) never collides between the aiden
+#    and max attestation runs) + final token ─────────────────────────────────
+echo "PRODUCT_GTM_PROOF: run_nonce=$(date -u +%Y%m%dT%H%M%S.%N)"
+echo "PRODUCT_GTM_PROOF: ALL PASS"
+exit 0

--- a/supabase/migrations/20260604_product_gtm_proof_contract.sql
+++ b/supabase/migrations/20260604_product_gtm_proof_contract.sql
@@ -32,6 +32,7 @@ SET LOCAL agency_os.callsign = 'scout';
 
 UPDATE public.gate_roadmap
    SET built_by_callsign = 'scout',
+       deploy_trigger = 'docs-artifact:docs/launch/KEI-131_gtm_launch_kit.md + ci:check_no_orphan_merge + proof_bar:product_gtm_proof.sh',
        proof_gate_contract = '{
         "check_id": "product_gtm_ready_v1",
         "cmd": "bash scripts/proof_bar/product_gtm_proof.sh",

--- a/supabase/migrations/20260604_product_gtm_proof_contract.sql
+++ b/supabase/migrations/20260604_product_gtm_proof_contract.sql
@@ -1,0 +1,143 @@
+-- ============================================================================
+-- 20260604_product_gtm_proof_contract.sql
+--
+-- Arms the product_gtm gate (gate_roadmap id
+-- f3f42557-40f5-4602-8239-ca09fa1da9e3, phase 6_product) for a built→proven
+-- attestation under the merge→deploy→prove rule. KEI ref: scout-product-gtm-proof.
+--
+-- proof_gate prose: "1-pager + launch comms approved and ready".
+--
+-- product_gtm is a DOCS/ARTIFACT-readiness gate, not a runtime service. The
+-- proof_bar (scripts/proof_bar/product_gtm_proof.sh) asserts the READY half —
+-- the launch kit artifact (docs/launch/KEI-131_gtm_launch_kit.md) exists at the
+-- committed repo_sha and contains the complete 1-pager (§1 incl. Pricing + CTA)
+-- + launch comms (§2 email, §3 social). The APPROVED half is the Aiden+Max
+-- dual-attest itself. Interpretation surfaced to Elliot before this PR.
+--
+-- WHAT THIS MIGRATION DOES
+--   1. Stamps built_by_callsign='scout' (was NULL — arms trg_04 + PR #1415
+--      watchdog; owner already scout).
+--   2. Attaches proof_gate_contract: cmd = the proof_bar script, the
+--      PRODUCT_GTM_PROOF tokens, role_sep builder=scout attester=[aiden,max].
+--      trg_01 Check A pins run_cmd to cmd exactly → pytest/mocked disqualified.
+--   3. Inline DO-block negative self-test (sentinel-raise / outer-rollback):
+--      trg_01 Check A refuses a pytest-shaped run_cmd. ABORTS otherwise.
+--
+-- NON-GOALS: the flip itself (trg_11 needs aiden+max binding_reviewer proof_runs;
+--   trg_08 write_guard means only their sessions insert them). No trigger changes.
+-- ============================================================================
+
+BEGIN;
+SET LOCAL agency_os.callsign = 'scout';
+
+UPDATE public.gate_roadmap
+   SET built_by_callsign = 'scout',
+       proof_gate_contract = '{
+        "check_id": "product_gtm_ready_v1",
+        "cmd": "bash scripts/proof_bar/product_gtm_proof.sh",
+        "expected_output_contains": [
+            "PRODUCT_GTM_PROOF: one-pager complete OK",
+            "PRODUCT_GTM_PROOF: launch-comms complete OK",
+            "PRODUCT_GTM_PROOF: artifact committed repo_sha=",
+            "PRODUCT_GTM_PROOF: ALL PASS"
+        ],
+        "role_sep": {
+            "builder": "scout",
+            "attester": ["aiden", "max"]
+        },
+        "negative_test_required": true
+   }'::jsonb,
+       notes = COALESCE(notes, '') || E'\n\n[scout-product-gtm-proof 2026-06-04] '
+            || 'Stamped built_by_callsign=scout. Attached proof_gate_contract '
+            || 'check_id=product_gtm_ready_v1. cmd is the artifact-readiness '
+            || 'proof_bar over docs/launch/KEI-131_gtm_launch_kit.md (1-pager + '
+            || 'launch comms; asserts sections present + committed at repo_sha). '
+            || 'READY is mechanically proven; APPROVED = the aiden+max dual-'
+            || 'attest. trg_01 Check A pins run_cmd → pytest/mocked disqualified.'
+ WHERE id = 'f3f42557-40f5-4602-8239-ca09fa1da9e3'::uuid;
+
+
+-- Inline negative self-test — trg_01 Check A MUST refuse a pytest-shaped run_cmd.
+DO $self_test$
+DECLARE
+    v_gate_id       uuid := gen_random_uuid();
+    v_run_id        uuid;
+    v_session_uuid  uuid := gen_random_uuid();
+    v_msg           text;
+BEGIN
+    BEGIN
+        SET LOCAL agency_os.callsign = 'atlas';
+        INSERT INTO public.gate_roadmap (
+            id, component, phase, subphase, proof_gate, proof_gate_contract,
+            status, required_attestation_kind, owner
+        ) VALUES (
+            v_gate_id,
+            'product_gtm_INLINE_NEGTEST_' || replace(v_gate_id::text, '-', ''),
+            '0_foundation', 'gates',
+            'inline product_gtm contract self-test row',
+            '{
+                "check_id": "product_gtm_inline_self_test",
+                "cmd": "bash scripts/proof_bar/product_gtm_proof.sh",
+                "expected_output_contains": ["PRODUCT_GTM_PROOF: ALL PASS"],
+                "role_sep": {"builder": "atlas", "attester": ["aiden"]},
+                "negative_test_required": true
+            }'::jsonb,
+            'built',
+            'binding_reviewer',
+            'atlas'
+        );
+
+        INSERT INTO public.tool_call_log (callsign, session_uuid, tool_name, started_at)
+        VALUES ('aiden', v_session_uuid, 'product_gtm_self_test_inline', now());
+
+        SET LOCAL agency_os.callsign = 'aiden';
+        INSERT INTO public.gate_proof_runs (
+            gate_roadmap_id, attestation_kind, run_cmd, run_output, output_sha256,
+            exit_code, attesting_callsign, attester_session_uuid, repo_sha
+        ) VALUES (
+            v_gate_id,
+            'binding_reviewer',
+            'pytest tests/test_gtm_mock.py -v',  -- WRONG (disqualified pytest shape)
+            'mocked output claiming PRODUCT_GTM_PROOF: ALL PASS but run_cmd is pytest not the proof_bar',
+            repeat('f', 64),
+            0,
+            'aiden',
+            v_session_uuid::text,
+            'selftest0000000000000000000000000000000a'  -- repo_sha_binding_check: len>=7
+        ) RETURNING id INTO v_run_id;
+
+        SET LOCAL agency_os.callsign = 'dave';
+        BEGIN
+            UPDATE public.gate_roadmap
+               SET status = 'proven', proof_run_id = v_run_id
+             WHERE id = v_gate_id;
+            RAISE EXCEPTION
+                'PRODUCT_GTM_SELF_TEST FAIL: UPDATE proven accepted; trg_01 was expected to refuse on Check A cmd mismatch'
+                USING ERRCODE = 'check_violation';
+        EXCEPTION WHEN check_violation THEN
+            GET STACKED DIAGNOSTICS v_msg = MESSAGE_TEXT;
+            IF v_msg NOT LIKE '%proof_gate_contract Check A%' THEN
+                RAISE EXCEPTION
+                    'PRODUCT_GTM_SELF_TEST FAIL: unexpected check_violation (wanted Check A cmd_mismatch): %', v_msg
+                    USING ERRCODE = 'check_violation';
+            END IF;
+        END;
+
+        RAISE EXCEPTION 'PRODUCT_GTM_SELF_TEST_OK' USING ERRCODE = 'check_violation';
+    EXCEPTION WHEN check_violation THEN
+        GET STACKED DIAGNOSTICS v_msg = MESSAGE_TEXT;
+        IF v_msg = 'PRODUCT_GTM_SELF_TEST_OK' THEN
+            RAISE NOTICE
+                'INLINE SELF-TEST PASS: trg_01 Check A refused pytest-shaped run_cmd; fixtures rolled back via outer sub-tx';
+        ELSE
+            RAISE EXCEPTION 'INLINE SELF-TEST FAIL or unexpected error: %', v_msg;
+        END IF;
+    END;
+END
+$self_test$;
+
+COMMIT;
+
+-- ============================================================================
+-- end of 20260604_product_gtm_proof_contract.sql
+-- ============================================================================


### PR DESCRIPTION
## What

Arms `product_gtm` (`gate_roadmap` f3f42557, phase 6_product, status=built) for built→proven under the merge→deploy→prove rule.

proof_gate: *"1-pager + launch comms approved and ready"*. **product_gtm is a docs-READINESS gate** (Elliot concur), not a runtime service — the proof_bar proves **READY**; **APPROVED = the Aiden+Max dual-attest** itself (same shape as three_store_sync).

## Files

1. **`scripts/proof_bar/product_gtm_proof.sh`** — asserts the launch-kit artifact `docs/launch/KEI-131_gtm_launch_kit.md` is complete: §1 One-Pager (incl. **Pricing** + **Call-to-action**), §2 Launch Email Template, §3 Social Launch Posts — and is **committed at the captured repo_sha** (not a dirty work-tree). Emits `PRODUCT_GTM_PROOF` tokens; exit 0.
2. **`supabase/migrations/20260604_product_gtm_proof_contract.sql`** — stamps `built_by_callsign='scout'` (arms trg_04 + #1415 watchdog), attaches `proof_gate_contract` (cmd=the proof_bar, role_sep builder=scout attester=[aiden,max]). Inline negative self-test (pytest-shaped run_cmd refused on Check A) — **PASS at apply**.

## Negative bar (structural)

`trg_01` Check A pins `run_cmd` to `bash scripts/proof_bar/product_gtm_proof.sh` exactly → any pytest/mocked run_cmd is `cmd_mismatch`-rejected.

## Verbatim proof_run (scout, this branch)

```
PRODUCT_GTM_PROOF: one-pager complete OK
PRODUCT_GTM_PROOF: launch-comms complete OK
PRODUCT_GTM_PROOF: artifact committed repo_sha=7434a488d9c00384089cabe6294a4ff3e98eab01 OK
PRODUCT_GTM_PROOF: run_nonce=20260604T052347.400892587
PRODUCT_GTM_PROOF: ALL PASS
EXIT: 0
```

## Flip path (post-merge, dual-attest)

Builder (scout) can't insert attesters' proof_runs (trg_08 write_guard). **Aiden** + **Max** each run the proof_bar in their own session, record a `binding_reviewer` proof_run, then flip proven (trg_01 A/B/C + trg_11).

⚠️ **New constraint discovered:** `gate_proof_runs_repo_sha_binding_check` now requires binding_reviewer proof_runs to set **`repo_sha` (≥7 chars)** = the deployed sha. Attesters must include `repo_sha` or the INSERT is rejected. (Surfaced here for fleet awareness.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)